### PR TITLE
For statement

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -239,6 +239,76 @@ namespace tempearly
         }
     }
 
+    ForNode::ForNode(const Handle<Node>& variable,
+                     const Handle<Node>& collection,
+                     const Handle<Node>& statement)
+        : m_variable(variable.Get())
+        , m_collection(collection.Get())
+        , m_statement(statement.Get()) {}
+
+    Result ForNode::Execute(const Handle<Interpreter>& interpreter) const
+    {
+        Value collection = m_collection->Evaluate(interpreter);
+        Value iterator;
+        Value element;
+
+        if (!collection || !(iterator = collection.Call(interpreter, "__iter__")))
+        {
+            return Result(Result::KIND_ERROR);
+        }
+        interpreter->PushScope(interpreter->GetScope());
+        while (iterator.GetNext(interpreter, element))
+        {
+            if (m_variable->AssignLocal(interpreter, element))
+            {
+                Result result = m_statement->Execute(interpreter);
+
+                switch (result.GetKind())
+                {
+                    case Result::KIND_SUCCESS:
+                    case Result::KIND_CONTINUE:
+                        break;
+
+                    case Result::KIND_BREAK:
+                        interpreter->PopScope();
+                        return Result();
+
+                    default:
+                        interpreter->PopScope();
+                        return result;
+                }
+            } else {
+                interpreter->PopScope();
+
+                return Result(Result::KIND_ERROR);
+            }
+        }
+        interpreter->PopScope();
+        if (interpreter->HasException())
+        {
+            return Result(Result::KIND_ERROR);
+        } else {
+            return Result();
+        }
+    }
+
+    void ForNode::Mark()
+    {
+        Node::Mark();
+        if (!m_variable->IsMarked())
+        {
+            m_variable->Mark();
+        }
+        if (!m_collection->IsMarked())
+        {
+            m_collection->Mark();
+        }
+        if (!m_statement->IsMarked())
+        {
+            m_statement->Mark();
+        }
+    }
+
     BreakNode::BreakNode() {}
 
     Result BreakNode::Execute(const Handle<Interpreter>& interpreter) const

--- a/src/node.h
+++ b/src/node.h
@@ -162,6 +162,24 @@ namespace tempearly
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(WhileNode);
     };
 
+    class ForNode : public Node
+    {
+    public:
+        explicit ForNode(const Handle<Node>& variable,
+                         const Handle<Node>& collection,
+                         const Handle<Node>& statement);
+
+        Result Execute(const Handle<Interpreter>& interpreter) const;
+
+        void Mark();
+
+    private:
+        Node* m_variable;
+        Node* m_collection;
+        Node* m_statement;
+        TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(ForNode);
+    };
+
     class BreakNode : public Node
     {
     public:

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1101,6 +1101,38 @@ SCAN_EXPONENT:
         return new WhileNode(condition, statement);
     }
 
+    static Handle<Node> parse_for(const Handle<Interpreter>& interpreter,
+                                  Parser* parser)
+    {
+        Handle<Node> variable;
+        Handle<Node> collection;
+        Handle<Node> statement;
+
+        if (!expect_token(interpreter, parser, Token::KW_FOR)
+            || !(variable = parse_expr(interpreter, parser)))
+        {
+            return Handle<Node>();
+        }
+        if (!variable->IsVariable())
+        {
+            interpreter->Throw(interpreter->eSyntaxError,
+                               "'for' loop requires variable");
+
+            return Handle<Node>();
+        }
+        if (!expect_token(interpreter, parser, Token::COLON)
+            || !(collection = parse_expr(interpreter, parser))
+            || !expect_token(interpreter, parser, Token::COLON)
+            || !(statement = parse_block(interpreter, parser))
+            || !expect_token(interpreter, parser, Token::KW_END)
+            || !expect_token(interpreter, parser, Token::KW_FOR))
+        {
+            return Handle<Node>();
+        }
+
+        return new ForNode(variable, collection, statement);
+    }
+
     static Handle<Node> parse_stmt(const Handle<Interpreter>& interpreter,
                                    Parser* parser)
     {
@@ -1130,7 +1162,8 @@ SCAN_EXPONENT:
             case Token::KW_WHILE:
                 return parse_while(interpreter, parser);
 
-            //TODO:case Token::KW_FOR:
+            case Token::KW_FOR:
+                return parse_for(interpreter, parser);
 
             case Token::KW_BREAK:
                 node = new BreakNode();


### PR DESCRIPTION
This commit adds `for` statement and fixes bug in parsing of `while`
statements.

Also adds new method `AssignLocal` for `Node` class which is useful in
`for` statement and function parameters (WIP feature).

For statements are iterating loops, not the kind of `for` you see in
C/C++. For statement has an variable node, collection node and body of
the loop. Collection node is evaluated into an object, and an iterator
is extracted from that object. Then the body of the loop is executed in
a sub-scope for every object extracted from the iterator, where those
objects are assigned to the variable node.

Example of usage:

``` html
<ul>
<% for value : [1, 2, 3, 4, 5]: %>
  <li>${value}</li>
<% end for %>
</ul>
```
