### PR TITLE
HTTP POST data parsing.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,5 +15,8 @@
 
 # Server APIs
 
+- Process multipart HTTP requests.
+- Parse request parameters (especially POSTed ones) only when requested in the
+  script.
 - FastCGI
 - Apache 2.x

--- a/src/sapi/cgi/cgi-request.h
+++ b/src/sapi/cgi/cgi-request.h
@@ -21,9 +21,11 @@ namespace tempearly
 
     private:
         void ReadEnvironmentVariables();
+        void ReadParameters();
 
     private:
         Dictionary<std::vector<String> > m_parameters;
+        bool m_parameters_read;
         /** Request method ("GET", "POST", etc.). */
         String m_method;
         /** Requested URI. */


### PR DESCRIPTION
Modifies `CgiRequest` class so that it can read parameters supplied with
HTTP POST.

Multipart requests however, yet remain on TODO list. Also, this method
is far away from being secure.
