### PR TITLE
Add simple HTTP server.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,18 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 PROJECT(tempearly C CXX)
 
+OPTION(
+    TEMPEARLY_ENABLE_CGI_SAPI
+    "Enable CGI SAPI"
+    ON
+)
+
+OPTION(
+    TEMPEARLY_ENABLE_HTTPD_SAPI
+    "Enable builtin HTTP server SAPI"
+    OFF
+)
+
 INCLUDE(CheckIncludeFile)
 INCLUDE(CheckIncludeFileCXX)
 
@@ -61,10 +73,24 @@ SET(
     src/core/stringbuilder.cc
 )
 
-ADD_EXECUTABLE(
-    tempearly-cgi
-    src/sapi/cgi/cgi-request.cc
-    src/sapi/cgi/cgi-response.cc
-    src/sapi/cgi/main.cc
-    ${INTERPRETER_SOURCES}
-)
+IF (TEMPEARLY_ENABLE_CGI_SAPI)
+    ADD_EXECUTABLE(
+        tempearly-cgi
+        src/sapi/cgi/cgi-request.cc
+        src/sapi/cgi/cgi-response.cc
+        src/sapi/cgi/main.cc
+        ${INTERPRETER_SOURCES}
+    )
+ENDIF()
+
+IF (TEMPEARLY_ENABLE_HTTPD_SAPI)
+    ADD_EXECUTABLE(
+        tempearly-httpd
+        src/sapi/httpd/httpd-request.cc
+        src/sapi/httpd/httpd-response.cc
+        src/sapi/httpd/main.cc
+        src/sapi/httpd/server.cc
+        src/sapi/httpd/socket.cc
+        ${INTERPRETER_SOURCES}
+    )
+ENDIF()

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -98,8 +98,8 @@ namespace tempearly
                 next = current->next;
                 current->id.~String();
                 current->value.~T();
-                current = next;
                 std::free(static_cast<void*>(current));
+                current = next;
             }
             delete[] m_bucket;
         }

--- a/src/sapi/httpd/httpd-request.cc
+++ b/src/sapi/httpd/httpd-request.cc
@@ -1,0 +1,109 @@
+#include "utils.h"
+#include "core/bytestring.h"
+#include "sapi/httpd/httpd-request.h"
+#include "sapi/httpd/socket.h"
+
+namespace tempearly
+{
+    HttpServerRequest::HttpServerRequest(const Handle<Socket>& socket,
+                                         const String& method,
+                                         const String& query_string,
+                                         const Dictionary<String>& headers,
+                                         const byte* data,
+                                         std::size_t data_size)
+        : m_socket(socket.Get())
+        , m_method(method)
+        , m_headers(headers)
+    {
+        if (!query_string.IsEmpty())
+        {
+            Utils::ParseQueryString(query_string, m_parameters);
+        }
+        if (m_method == "POST"
+            && GetContentType() == "application/x-www-form-urlencoded"
+            && GetContentLength() > 0)
+        {
+            Utils::ParseQueryString(ByteString(data, data_size).c_str(), m_parameters);
+        }
+    }
+
+    String HttpServerRequest::GetMethod() const
+    {
+        return m_method;
+    }
+
+    bool HttpServerRequest::HasParameter(const String& id) const
+    {
+        const Dictionary<std::vector<String> >::Entry* e = m_parameters.Find(id);
+
+        return e && !e->value.empty();
+    }
+
+    bool HttpServerRequest::GetParameter(const String& id, String& slot) const
+    {
+        const Dictionary<std::vector<String> >::Entry* e = m_parameters.Find(id);
+
+        if (e && !e->value.empty())
+        {
+            slot = e->value.front();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    bool HttpServerRequest::HasHeader(const String& id) const
+    {
+        return m_headers.Find(id);
+    }
+
+    bool HttpServerRequest::GetHeader(const String& id, String& slot) const
+    {
+        const Dictionary<String>::Entry* e = m_headers.Find(id);
+
+        if (e)
+        {
+            slot = e->value;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    String HttpServerRequest::GetContentType() const
+    {
+        String value;
+
+        GetHeader("Content-Type", value);
+
+        return value;
+    }
+
+    std::size_t HttpServerRequest::GetContentLength() const
+    {
+        String value;
+
+        if (GetHeader("Content-Length", value))
+        {
+            i64 slot;
+
+            if (Utils::ParseInt(value, slot, 10))
+            {
+                return static_cast<std::size_t>(slot);
+            }
+        }
+
+        return 0;
+    }
+
+    void HttpServerRequest::Mark()
+    {
+        Request::Mark();
+        if (m_socket && !m_socket->IsMarked())
+        {
+            m_socket->Mark();
+        }
+    }
+}

--- a/src/sapi/httpd/httpd-request.h
+++ b/src/sapi/httpd/httpd-request.h
@@ -1,0 +1,46 @@
+#ifndef TEMPEARLY_SAPI_HTTPD_HTTPD_REQUEST_H_GUARD
+#define TEMPEARLY_SAPI_HTTPD_HTTPD_REQUEST_H_GUARD
+
+#include "dictionary.h"
+#include "request.h"
+
+namespace tempearly
+{
+    class Socket;
+
+    class HttpServerRequest : public Request
+    {
+    public:
+        explicit HttpServerRequest(const Handle<Socket>& socket,
+                                   const String& method,
+                                   const String& query_string,
+                                   const Dictionary<String>& headers,
+                                   const byte* data,
+                                   std::size_t data_size);
+
+        String GetMethod() const;
+
+        bool HasParameter(const String& id) const;
+
+        bool GetParameter(const String& id, String& slot) const;
+
+        bool HasHeader(const String& id) const;
+
+        bool GetHeader(const String& id, String& slot) const;
+
+        String GetContentType() const;
+
+        std::size_t GetContentLength() const;
+
+        void Mark();
+
+    private:
+        Socket* m_socket;
+        String m_method;
+        Dictionary<String> m_headers;
+        Dictionary<std::vector<String> > m_parameters;
+        TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(HttpServerRequest);
+    };
+}
+
+#endif /* !TEMPEARLY_SAPI_HTTPD_HTTPD_REQUEST_H_GUARD */

--- a/src/sapi/httpd/httpd-response.cc
+++ b/src/sapi/httpd/httpd-response.cc
@@ -1,0 +1,76 @@
+#include "api/exception.h"
+#include "core/bytestring.h"
+#include "sapi/httpd/httpd-response.h"
+#include "sapi/httpd/socket.h"
+
+namespace tempearly
+{
+    HttpServerResponse::HttpServerResponse(const Handle<Socket>& socket)
+        : m_socket(socket.Get())
+        , m_committed(false) {}
+
+    bool HttpServerResponse::IsCommitted() const
+    {
+        return m_committed;
+    }
+
+    void HttpServerResponse::Commit()
+    {
+        if (m_committed)
+        {
+            return;
+        }
+        m_committed = true;
+        m_socket->Printf("HTTP/1.0 %d\r\n", GetStatus()); // TODO: status message
+        for (const Dictionary<String>::Entry* e = GetHeaders().GetFront();
+             e;
+             e = e->next)
+        {
+            m_socket->Printf("%s: %s\r\n",
+                             e->id.Encode().c_str(),
+                             e->value.Encode().c_str());
+        }
+        m_socket->Send("\r\n", 2);
+        // TODO: flush the socket
+    }
+
+    void HttpServerResponse::Write(std::size_t size, const char* data)
+    {
+        if (!m_committed)
+        {
+            Commit();
+        }
+        m_socket->Send(data, size);
+    }
+
+    void HttpServerResponse::SendException(const Handle<ExceptionObject>& exception)
+    {
+        if (!exception)
+        {
+            return; // Just in case.
+        }
+        if (m_committed)
+        {
+            m_socket->Printf(
+                "<p><strong>ERROR:</strong> %s</p>",
+                exception->GetMessage().Encode().c_str()
+            );
+        } else {
+            m_committed = true;
+            m_socket->Printf("HTTP/1.0 500 Internal Server Error\r\n");
+            m_socket->Printf("Content-Type: text/plain; charset=utf-8\r\n\r\n");
+            m_socket->Printf("ERROR:\n%s\n",
+                             exception->GetMessage().Encode().c_str());
+            // TODO: flush socket
+        }
+    }
+
+    void HttpServerResponse::Mark()
+    {
+        Response::Mark();
+        if (m_socket && !m_socket->IsMarked())
+        {
+            m_socket->Mark();
+        }
+    }
+}

--- a/src/sapi/httpd/httpd-response.h
+++ b/src/sapi/httpd/httpd-response.h
@@ -1,0 +1,32 @@
+#ifndef TEMPEARLY_SAPI_HTTPD_HTTPD_RESPONSE_H_GUARD
+#define TEMPEARLY_SAPI_HTTPD_HTTPD_RESPONSE_H_GUARD
+
+#include "response.h"
+
+namespace tempearly
+{
+    class Socket;
+
+    class HttpServerResponse : public Response
+    {
+    public:
+        explicit HttpServerResponse(const Handle<Socket>& socket);
+
+        bool IsCommitted() const;
+
+        void Commit();
+
+        void Write(std::size_t size, const char* data);
+
+        void SendException(const Handle<ExceptionObject>& exception);
+
+        void Mark();
+
+    private:
+        Socket* m_socket;
+        bool m_committed;
+        TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(HttpServerResponse);
+    };
+}
+
+#endif /* !TEMPEARLY_SAPI_HTTPD_HTTPD_RESPONSE_H_GUARD */

--- a/src/sapi/httpd/main.cc
+++ b/src/sapi/httpd/main.cc
@@ -1,0 +1,114 @@
+#include <sys/stat.h>
+
+#include "utils.h"
+#include "core/bytestring.h"
+#include "sapi/httpd/socket.h"
+
+using namespace tempearly;
+
+namespace tempearly
+{
+    extern void httpd_loop(const Handle<Socket>&, const String&);
+}
+
+static bool parse_directory(const String&, String&);
+static bool parse_host_and_port(const String&, String&, int&);
+
+static const char* httpd_usage = "usage: %s [port] [directory]";
+
+int main(int argc, char** argv)
+{
+    Handle<Socket> socket;
+    String host = "0.0.0.0";
+    int port = 8000;
+    String path = ".";
+
+    if (argc > 3)
+    {
+        std::fprintf(stderr, httpd_usage, argv[0]);
+
+        return EXIT_FAILURE;
+    }
+    else if (argc > 2)
+    {
+        if (!parse_host_and_port(argv[1], host, port)
+            || !parse_directory(argv[2], path))
+        {
+            std::fprintf(stderr, httpd_usage, argv[0]);
+
+            return EXIT_FAILURE;
+        }
+    }
+    else if (argc > 1)
+    {
+        if (!parse_host_and_port(argv[1], host, port))
+        {
+            std::fprintf(stderr, httpd_usage, argv[0]);
+
+            return EXIT_FAILURE;
+        }
+    }
+    socket = new Socket();
+    if (!socket->Create(port, SOCK_STREAM, host) || !socket->Listen(25))
+    {
+        std::fprintf(stderr, "couldn't initialize server: %s",
+                     socket->GetErrorMessage().Encode().c_str());
+
+        return EXIT_FAILURE;
+    }
+
+    std::fprintf(stdout, "HTTP-server running at http://%s:%d/\n",
+                 host.Encode().c_str(),
+                 port);
+
+    tempearly::httpd_loop(socket, path);
+
+    return EXIT_SUCCESS;
+}
+
+static bool parse_directory(const String& input, String& slot)
+{
+    struct stat st;
+
+    if (stat(input.Encode().c_str(), &st) >= 0 && S_ISDIR(st.st_mode))
+    {
+        slot = input;
+
+        return true;
+    }
+
+    return false;
+}
+
+static bool parse_host_and_port(const String& input, String& host, int& port)
+{
+    std::size_t index = input.IndexOf(':');
+    String port_source;
+    bool port_specified = false;
+
+    if (index != String::npos)
+    {
+        host = input.SubString(0, index);
+        port_source = input.SubString(index + 1);
+        port_specified = true;
+    }
+    else if (input.IndexOf('.') != String::npos)
+    {
+        host = input;
+    } else {
+        port_source = input;
+        port_specified = true;
+    }
+    if (port_specified)
+    {
+        i64 slot;
+
+        if (!Utils::ParseInt(port_source, slot, 10))
+        {
+            return false;
+        }
+        port = static_cast<int>(slot);
+    }
+
+    return true;
+}

--- a/src/sapi/httpd/server.cc
+++ b/src/sapi/httpd/server.cc
@@ -1,0 +1,471 @@
+#include <cstring>
+#include <vector>
+
+#include <sys/stat.h>
+
+#include "dictionary.h"
+#include "interpreter.h"
+#include "core/bytestring.h"
+#include "core/stringbuilder.h"
+#include "sapi/httpd/httpd-request.h"
+#include "sapi/httpd/httpd-response.h"
+#include "sapi/httpd/socket.h"
+
+#if !defined(HTTPD_MAX_REQUEST_SIZE)
+# define HTTPD_MAX_REQUEST_SIZE 4096
+#endif
+
+namespace tempearly
+{
+    enum HttpMethod
+    {
+        HTTP_METHOD_GET,
+        HTTP_METHOD_HEAD,
+        HTTP_METHOD_POST,
+        HTTP_METHOD_PUT,
+        HTTP_METHOD_DELETE,
+        HTTP_METHOD_TRACE,
+        HTTP_METHOD_OPTIONS,
+        HTTP_METHOD_CONNECT,
+        HTTP_METHOD_PATCH
+    };
+
+    enum HttpVersion
+    {
+        HTTP_VERSION_09,
+        HTTP_VERSION_10,
+        HTTP_VERSION_11
+    };
+
+    struct HttpRequestData
+    {
+        String method;
+        String path;
+        String query_string;
+        HttpVersion version;
+        Dictionary<String> headers;
+    };
+
+    struct MimeTypeMapping
+    {
+        const char* ext;
+        const char* mime_type;
+    };
+
+    static const MimeTypeMapping default_mime_types[] =
+    {
+        { "html", "text/html" },
+        { "htm", "text/htm" },
+        { "js", "text/javascript" },
+        { "css", "text/css" },
+        { "gif", "image/gif" },
+        { "jpg", "image/jpeg" },
+        { "jpeg", "image/jpeg" },
+        { "jpe", "image/jpeg" },
+        { "pdf", "application/pdf" },
+        { "png", "image/png" },
+        { "svg", "image/svg+xml" },
+        { "txt", "text/plain" },
+        { 0, 0 }
+    };
+
+    static Dictionary<HttpMethod> http_method_map;
+    static Dictionary<HttpVersion> http_version_map;
+    static Dictionary<String> mime_type_map;
+
+    static byte* parse_request(byte*, std::size_t&, HttpRequestData&);
+    static void send_error(const Handle<Socket>&, const char*, const String&);
+    static void send_file(const Handle<Socket>&, HttpRequestData&, const ByteString&, std::size_t, const String&);
+    static void send_script(const Handle<Socket>&, HttpRequestData&, const String&, const byte*, std::size_t);
+    static String normalize(const String&, const String&, String&);
+    static String get_mime_type(const String&);
+
+    static void serve(const Handle<Socket>& socket, const String& root_path)
+    {
+        HttpRequestData data;
+        byte buffer[HTTPD_MAX_REQUEST_SIZE];
+        std::size_t buffer_size;
+        byte* data_begin;
+        struct stat st;
+        String path;
+        ByteString path_encoded;
+        String extension;
+
+        if (!socket->Receive(buffer, HTTPD_MAX_REQUEST_SIZE, buffer_size))
+        {
+            socket->Close();
+            return;
+        }
+
+        if (!(data_begin = parse_request(buffer, buffer_size, data)))
+        {
+            send_error(socket,
+                       "400 Bad Request",
+                       "We were unable to process your request.\n");
+            return;
+        }
+
+        std::fprintf(stdout, "%s %s\n",
+                     data.method.Encode().c_str(),
+                     data.path.Encode().c_str());
+
+        path = normalize(root_path, data.path, extension);
+        path_encoded = path.Encode();
+
+        if (::stat(path_encoded.c_str(), &st) < 0)
+        {
+            send_error(socket,
+                       "404 Not Found",
+                       "The requested URL "
+                       + data.path
+                       + " was not found on this server.");
+        }
+        else if (S_ISDIR(st.st_mode))
+        {
+            // TODO: Look for index file.
+            send_error(socket,
+                       "403 Forbidden",
+                       "You don't have permission to access "
+                       + data.path
+                       + " on this server");
+        }
+        else if (extension == "tly")
+        {
+            send_script(socket,
+                        data,
+                        path,
+                        data_begin,
+                        buffer_size);
+        } else {
+            send_file(socket,
+                      data,
+                      path_encoded,
+                      st.st_size,
+                      get_mime_type(extension));
+        }
+    }
+
+    void httpd_loop(const Handle<Socket>& server_socket,
+                    const String& root_path)
+    {
+        for (;;)
+        {
+            Handle<Socket> client_socket = server_socket->Accept();
+
+            if (client_socket)
+            {
+                serve(client_socket, root_path);
+            } else {
+                std::fprintf(stderr, "%s\n",
+                             server_socket->GetErrorMessage().Encode().c_str());
+            }
+        }
+    }
+
+    static void send_error(const Handle<Socket>& socket, const char* status, const String& message)
+    {
+        ByteString content = message.Encode();
+
+        socket->Printf("HTTP/1.0 %s\r\n", status);
+        socket->Printf("Content-Type: text/plain; charset=utf-8\r\n");
+        socket->Printf("Content-Length: %ld\r\n\r\n", content.GetLength());
+        socket->Send(content.c_str(), content.GetLength());
+    }
+
+    static void send_file(const Handle<Socket>& socket,
+                          HttpRequestData& data,
+                          const ByteString& path,
+                          std::size_t size,
+                          const String& mime_type)
+    {
+        FILE* fp = std::fopen(path.c_str(), "rb");
+        char buffer[4096];
+        std::size_t read;
+
+        if (!fp)
+        {
+            send_error(socket,
+                       "403 Forbidden",
+                       "You don't have permission to access "
+                       + data.path
+                       + " on this server");
+            return;
+        }
+        socket->Printf("HTTP/1.0 200 OK\r\n");
+        socket->Printf("Content-Type: %s\r\n", mime_type.Encode().c_str());
+        socket->Printf("Content-Length: %ld\r\n\r\n", size);
+        while ((read = std::fread(buffer, 1, sizeof(buffer), fp)) > 0)
+        {
+            if (!socket->Send(buffer, read))
+            {
+                break;
+            }
+        }
+        std::fclose(fp);
+        socket->Close();
+    }
+
+    static void send_script(const Handle<Socket>& socket,
+                            HttpRequestData& data,
+                            const String& path,
+                            const byte* data_begin,
+                            std::size_t data_size)
+    {
+        Handle<Interpreter> interpreter = new Interpreter();
+
+        interpreter->request = new HttpServerRequest(
+            socket,
+            data.method,
+            data.query_string,
+            data.headers,
+            data_begin,
+            data_size
+        );
+        interpreter->response = new HttpServerResponse(socket);
+        interpreter->Initialize();
+        if (!interpreter->Include(path))
+        {
+            interpreter->response->SendException(interpreter->GetException());
+        }
+        socket->Close();
+    }
+
+    static bool is_valid_http_method(const String& string)
+    {
+        if (http_method_map.IsEmpty())
+        {
+            http_method_map.Insert("GET", HTTP_METHOD_GET);
+            http_method_map.Insert("HEAD", HTTP_METHOD_HEAD);
+            http_method_map.Insert("POST", HTTP_METHOD_POST);
+            http_method_map.Insert("PUT", HTTP_METHOD_PUT);
+            http_method_map.Insert("DELETE", HTTP_METHOD_DELETE);
+            http_method_map.Insert("TRACE", HTTP_METHOD_TRACE);
+            http_method_map.Insert("OPTIONS", HTTP_METHOD_OPTIONS);
+            http_method_map.Insert("CONNECT", HTTP_METHOD_CONNECT);
+            http_method_map.Insert("PATCH", HTTP_METHOD_PATCH);
+        }
+
+        return http_method_map.Find(string);
+    }
+
+    static bool parse_http_version(const String& string, HttpVersion& version)
+    {
+        const Dictionary<HttpVersion>::Entry* entry;
+
+        if (http_version_map.IsEmpty())
+        {
+            http_version_map.Insert("HTTP/0.9", HTTP_VERSION_09);
+            http_version_map.Insert("HTTP/1.0", HTTP_VERSION_10);
+            http_version_map.Insert("HTTP/1.1", HTTP_VERSION_11);
+        }
+        if ((entry = http_version_map.Find(string)))
+        {
+            version = entry->value;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool parse_request_line(const String& line, HttpRequestData& data)
+    {
+        std::size_t index1;
+        std::size_t index2;
+
+        if ((index1 = line.IndexOf(' ')) == String::npos)
+        {
+            return false;
+        }
+
+        if (!is_valid_http_method(data.method = line.SubString(0, index1++)))
+        {
+            return false;
+        }
+
+        if ((index2 = line.IndexOf(' ', index1)) == String::npos)
+        {
+            data.path = line.SubString(index1);
+            data.version = HTTP_VERSION_09;
+        } else {
+            data.path = line.SubString(index1, index2 - index1);
+            if (!parse_http_version(line.SubString(index2 + 1), data.version))
+            {
+                return false;
+            }
+        }
+
+        // Split query string from request path.
+        if ((index1 = data.path.IndexOf('?')))
+        {
+            data.query_string = data.path.SubString(index1 + 1);
+            data.path = data.path.SubString(0, index1);
+        }
+
+        return true;
+    }
+
+    static bool parse_request_header(const String& line, HttpRequestData& data)
+    {
+        std::size_t index = line.IndexOf(':');
+
+        if (index == String::npos || index < 1)
+        {
+            return false;
+        }
+        data.headers.Insert(line.SubString(0, index), line.SubString(index + 2));
+
+        return true;
+    }
+
+    static byte* parse_request(byte* start,
+                               std::size_t& remain,
+                               HttpRequestData& data)
+    {
+        byte* begin = start;
+        byte* end = static_cast<byte*>(std::memchr(begin, '\n', remain));
+
+        if (!end)
+        {
+            return 0;
+        }
+
+        remain -= end - start + 1;
+        start = end + 1;
+        if (end > begin && end[-1] == '\r')
+        {
+            --end;
+        }
+        *end = '\0';
+
+        // Process first line of request
+        if (!parse_request_line(reinterpret_cast<char*>(begin), data))
+        {
+            return 0;
+        }
+
+        // Process request headers.
+        for (;;)
+        {
+            begin = start;
+            if (!(end = static_cast<byte*>(std::memchr(begin, '\n', remain))))
+            {
+                return 0;
+            }
+
+            remain -= end - start + 1;
+            start = end + 1;
+            if (end > begin && end[-1] == '\r')
+            {
+                --end;
+            }
+            *end = '\0';
+
+            if (!*begin)
+            {
+                return start;
+            }
+            else if (!parse_request_header(reinterpret_cast<char*>(begin), data))
+            {
+                return 0;
+            }
+        }
+    }
+
+    static void append(std::vector<String>& elements, const String& entry)
+    {
+        const std::size_t length = entry.GetLength();
+
+        if (length == 0 || (length == 1 && entry[0] == '.'))
+        {
+            return;
+        }
+        else if (length == 2 && entry[0] == '.' && entry[1] == '.')
+        {
+            if (!elements.empty())
+            {
+                elements.pop_back();
+            }
+        } else {
+            elements.push_back(entry);
+        }
+    }
+
+    static String normalize(const String& root,
+                            const String& path,
+                            String& extension)
+    {
+        std::vector<String> elements;
+        std::size_t begin = 0;
+        std::size_t end = 0;
+        StringBuilder result;
+
+        elements.push_back(root);
+        for (std::size_t i = 0; i < path.GetLength(); ++i)
+        {
+            if (path[i] == '/' || path[i] == '\\')
+            {
+                if (begin - end > 0)
+                {
+                    append(elements, path.SubString(begin, end - begin));
+                }
+                begin = end = i + 1;
+            } else {
+                ++end;
+            }
+        }
+        if (begin - end > 0)
+        {
+            append(elements, path.SubString(begin, end - begin));
+        }
+
+        // Extract extension from last component of the path.
+        if (!elements.empty())
+        {
+            const String& filename = elements[elements.size() - 1];
+            std::size_t index = filename.IndexOf('.');
+
+            if (index != String::npos && index > 0)
+            {
+                extension = filename.SubString(index + 1);
+            }
+        }
+
+        // Build the path again.
+        result.Reserve(path.GetLength());
+        for (std::size_t i = 0; i < elements.size(); ++i)
+        {
+            if (!result.IsEmpty())
+            {
+#if defined(_WIN32)
+                result << '\\';
+#else
+                result << '/';
+#endif
+            }
+            result << elements[i];
+        }
+
+        return result.ToString();
+    }
+
+    static String get_mime_type(const String& extension)
+    {
+        const Dictionary<String>::Entry* entry;
+
+        if (mime_type_map.IsEmpty())
+        {
+            for (int i = 0; default_mime_types[i].ext; ++i)
+            {
+                mime_type_map.Insert(default_mime_types[i].ext,
+                                     default_mime_types[i].mime_type);
+            }
+        }
+        if ((entry = mime_type_map.Find(extension)))
+        {
+            return entry->value;
+        } else {
+            return "application/octet-stream";
+        }
+    }
+}

--- a/src/sapi/httpd/socket.cc
+++ b/src/sapi/httpd/socket.cc
@@ -1,0 +1,159 @@
+#include <cerrno>
+#include <cstring>
+#include <cstdarg>
+
+#include "core/bytestring.h"
+#include "socket.h"
+
+namespace tempearly
+{
+    Socket::Socket()
+        : m_fd(-1) {}
+
+    Socket::~Socket()
+    {
+        Close();
+    }
+
+    bool Socket::Create(int port, int type, const String& host)
+    {
+        Close();
+        if ((m_fd = ::socket(AF_INET, type, 0)) < 0)
+        {
+            m_error_message = std::strerror(errno);
+            errno = 0;
+
+            return false;
+        }
+
+        // If bindable socket is being created, set the address:port reusable.
+        if (port || type == SOCK_STREAM)
+        {
+            int value = 1;
+
+            ::setsockopt(m_fd, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char*>(&value), sizeof(value));
+        }
+
+        std::memset(static_cast<void*>(&m_address), 0, sizeof(m_address));
+        m_address.sin_family = AF_INET;
+        if (host.IsEmpty())
+        {
+            m_address.sin_addr.s_addr = htonl(INADDR_ANY);
+        } else {
+            m_address.sin_addr.s_addr = inet_addr(host.Encode().c_str());
+        }
+        m_address.sin_port = htons(port);
+        if (port || type == SOCK_DGRAM || !host.IsEmpty())
+        {
+            return Bind();
+        }
+
+        return true;
+    }
+
+    bool Socket::Bind()
+    {
+        if (::bind(m_fd, reinterpret_cast<sockaddr*>(&m_address), sizeof(m_address)) < 0)
+        {
+            m_error_message = std::strerror(errno);
+            errno = 0;
+
+            return false;
+        }
+
+        return true;
+    }
+
+    bool Socket::Close()
+    {
+        int retval = 0;
+
+        if (m_fd >= 0)
+        {
+            retval = ::close(m_fd);
+        }
+        m_fd = -1;
+
+        return retval >= 0;
+    }
+
+    bool Socket::Listen(int max_connections)
+    {
+        if (::listen(m_fd, max_connections) < 0)
+        {
+            m_error_message = std::strerror(errno);
+            errno = 0;
+
+            return false;
+        }
+
+        return true;
+    }
+
+    Handle<Socket> Socket::Accept()
+    {
+        Handle<Socket> socket;
+        sockaddr_in address;
+        socklen_t len = static_cast<socklen_t>(sizeof(sockaddr_in));
+        int fd;
+
+ACCEPT_AGAIN:
+        if ((fd = ::accept(m_fd, reinterpret_cast<sockaddr*>(&address), &len)) < 0)
+        {
+            if (errno == EINTR)
+            {
+                goto ACCEPT_AGAIN;
+            }
+
+            return Handle<Socket>();
+        }
+        socket = new Socket();
+        socket->m_fd = fd;
+
+        return socket;
+    }
+
+    bool Socket::Receive(byte* buffer, std::size_t size, std::size_t& read)
+    {
+        int length;
+
+        std::memset(buffer, 0, size);
+        if ((length = ::recv(m_fd, buffer, sizeof(char) * size, 0)) < 0)
+        {
+            m_error_message = std::strerror(errno);
+            errno = 0;
+
+            return false;
+        }
+        read = static_cast<std::size_t>(length);
+
+        return true;
+    }
+
+    bool Socket::Send(const char* data, std::size_t size)
+    {
+        int length = ::send(m_fd, data, size, 0);
+
+        if (length < 0)
+        {
+            m_error_message = std::strerror(errno);
+            errno = 0;
+
+            return false;
+        }
+
+        return true;
+    }
+
+    void Socket::Printf(const char* format, ...)
+    {
+        char buffer[1024];
+        int length;
+        va_list ap;
+
+        va_start(ap, format);
+        length = vsnprintf(buffer, sizeof(buffer), format, ap);
+        va_end(ap);
+        Send(buffer, length);
+    }
+}

--- a/src/sapi/httpd/socket.h
+++ b/src/sapi/httpd/socket.h
@@ -1,0 +1,62 @@
+#ifndef TEMPERALY_SAPI_SOCKET_H_GUARD
+#define TEMPEARLY_SAPI_HTTPD_SOCKET_H_GUARD
+
+#include "core/string.h"
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <errno.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <unistd.h>
+
+#include "defines.h"
+
+namespace tempearly
+{
+    /**
+     * Unix socket wrapper base class.
+     */
+    class Socket : public CountedObject
+    {
+    public:
+        explicit Socket();
+
+        virtual ~Socket();
+
+        inline bool HasError() const
+        {
+            return !m_error_message.IsEmpty();
+        }
+
+        inline const String& GetErrorMessage() const
+        {
+            return m_error_message;
+        }
+
+        bool Create(int port, int type, const String& host);
+
+        bool Bind();
+
+        bool Close();
+
+        bool Listen(int max_connections);
+
+        Handle<Socket> Accept();
+
+        bool Receive(byte* buffer, std::size_t size, std::size_t& read);
+
+        bool Send(const char* data, std::size_t size);
+
+        void Printf(const char* format, ...);
+
+    private:
+        int m_fd;
+        sockaddr_in m_address;
+        String m_error_message;
+        TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(Socket);
+    };
+}
+
+#endif /* !TEMPEARLY_SAPI_HTTPD_SOCKET_H_GUARD */


### PR DESCRIPTION
Adds new SAPI which is minimal HTTP server capable of serving files and
Tempearly scripts in current working directory.

Useful when debugging and testing the interpreter and possibly later
when developing Tempearly scripts.
