### PR TITLE
Move HTTP enums into their own files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ SET(
     src/core/string.cc
     src/core/stringbuilder.cc
     src/http/cookie.cc
+    src/http/method.cc
+    src/http/version.cc
     src/sapi/request.cc
     src/sapi/response.cc
 )

--- a/src/api/request.cc
+++ b/src/api/request.cc
@@ -9,7 +9,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(req_method)
     {
-        return Value::NewString(interpreter->request->GetMethod());
+        return Value::NewString(HttpMethod::ToString(interpreter->request->GetMethod()));
     }
 
     /**

--- a/src/http/method.cc
+++ b/src/http/method.cc
@@ -1,0 +1,60 @@
+#include "core/dictionary.h"
+#include "http/method.h"
+
+namespace tempearly
+{
+    typedef Dictionary<HttpMethod::Kind> HttpMethodMap;
+
+    static HttpMethodMap method_map;
+
+    static void fill_method_map()
+    {
+        method_map.Insert("GET", HttpMethod::GET);
+        method_map.Insert("HEAD", HttpMethod::HEAD);
+        method_map.Insert("POST", HttpMethod::POST);
+        method_map.Insert("PUT", HttpMethod::PUT);
+        method_map.Insert("DELETE", HttpMethod::DELETE);
+        method_map.Insert("TRACE", HttpMethod::TRACE);
+        method_map.Insert("OPTIONS", HttpMethod::OPTIONS);
+        method_map.Insert("CONNECT", HttpMethod::CONNECT);
+        method_map.Insert("PATCH", HttpMethod::PATCH);
+    }
+
+    bool HttpMethod::Parse(const String& string, Kind& slot)
+    {
+        const Dictionary<Kind>::Entry* entry;
+
+        if (method_map.IsEmpty())
+        {
+            fill_method_map();
+        }
+        // TODO: make this case ignorant
+        if ((entry = method_map.Find(string)))
+        {
+            slot = entry->value;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    String HttpMethod::ToString(Kind kind)
+    {
+        if (method_map.IsEmpty())
+        {
+            fill_method_map();
+        }
+        for (const HttpMethodMap::Entry* entry = method_map.GetFront();
+             entry;
+             entry = entry->next)
+        {
+            if (entry->value == kind)
+            {
+                return entry->id;
+            }
+        }
+
+        return "UNKNOWN";
+    }
+}

--- a/src/http/method.h
+++ b/src/http/method.h
@@ -1,0 +1,33 @@
+#ifndef TEMPEARLY_HTTP_METHOD_H_GUARD
+#define TEMPEARLY_HTTP_METHOD_H_GUARD
+
+#include "tempearly.h"
+
+namespace tempearly
+{
+    class HttpMethod
+    {
+    public:
+        enum Kind
+        {
+            GET,
+            HEAD,
+            POST,
+            PUT,
+            DELETE,
+            TRACE,
+            OPTIONS,
+            CONNECT,
+            PATCH
+        };
+
+        static bool Parse(const String& string, Kind& slot);
+
+        static String ToString(Kind kind);
+
+    private:
+        TEMPEARLY_DISALLOW_IMPLICIT_CONSTRUCTORS(HttpMethod);
+    };
+}
+
+#endif /* !TEMPEARLY_HTTP_METHOD_H_GUARD */

--- a/src/http/version.cc
+++ b/src/http/version.cc
@@ -1,0 +1,53 @@
+#include "core/dictionary.h"
+#include "http/version.h"
+
+namespace tempearly
+{
+    typedef Dictionary<HttpVersion::Kind> HttpVersionMap;
+
+    static HttpVersionMap version_map;
+
+    static void fill_version_map()
+    {
+        version_map.Insert("HTTP/0.9", HttpVersion::VERSION_09);
+        version_map.Insert("HTTP/1.0", HttpVersion::VERSION_10);
+        version_map.Insert("HTTP/1.1", HttpVersion::VERSION_11);
+    }
+
+    bool HttpVersion::Parse(const String& string, Kind& slot)
+    {
+        const HttpVersionMap::Entry* entry;
+
+        if (version_map.IsEmpty())
+        {
+            fill_version_map();
+        }
+        if ((entry = version_map.Find(string)))
+        {
+            slot = entry->value;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    String HttpVersion::ToString(Kind kind)
+    {
+        if (version_map.IsEmpty())
+        {
+            fill_version_map();
+        }
+        for (const HttpVersionMap::Entry* entry = version_map.GetFront();
+             entry;
+             entry = entry->next)
+        {
+            if (entry->value == kind)
+            {
+                return entry->id;
+            }
+        }
+
+        return "UNKNOWN";
+    }
+}

--- a/src/http/version.h
+++ b/src/http/version.h
@@ -1,0 +1,27 @@
+#ifndef TEMPEARLY_HTTP_VERSION_H_GUARD
+#define TEMPEARLY_HTTP_VERSION_H_GUARD
+
+#include "tempearly.h"
+
+namespace tempearly
+{
+    class HttpVersion
+    {
+    public:
+        enum Kind
+        {
+            VERSION_09 = 9,
+            VERSION_10 = 10,
+            VERSION_11 = 11
+        };
+
+        static bool Parse(const String& string, Kind& slot);
+
+        static String ToString(Kind kind);
+
+    private:
+        TEMPEARLY_DISALLOW_IMPLICIT_CONSTRUCTORS(HttpVersion);
+    };
+}
+
+#endif /* !TEMPEARLY_HTTP_VERSION_H_GUARD */

--- a/src/sapi/cgi/cgi-request.cc
+++ b/src/sapi/cgi/cgi-request.cc
@@ -35,6 +35,18 @@ namespace tempearly
 #endif
     }
 
+    HttpMethod::Kind CgiRequest::GetMethod() const
+    {
+        HttpMethod::Kind method;
+
+        if (HttpMethod::Parse(m_method, method))
+        {
+            return method;
+        } else {
+            return HttpMethod::GET;
+        }
+    }
+
     bool CgiRequest::HasParameter(const String& id) const
     {
         const Dictionary<std::vector<String> >::Entry* e = m_parameters.Find(id);

--- a/src/sapi/cgi/cgi-request.h
+++ b/src/sapi/cgi/cgi-request.h
@@ -10,10 +10,7 @@ namespace tempearly
     public:
         explicit CgiRequest();
 
-        String GetMethod() const
-        {
-            return m_method;
-        }
+        HttpMethod::Kind GetMethod() const;
 
         bool HasParameter(const String& id) const;
 

--- a/src/sapi/httpd/httpd-request.cc
+++ b/src/sapi/httpd/httpd-request.cc
@@ -6,7 +6,7 @@
 namespace tempearly
 {
     HttpServerRequest::HttpServerRequest(const Handle<Socket>& socket,
-                                         const String& method,
+                                         HttpMethod::Kind method,
                                          const String& query_string,
                                          const Dictionary<String>& headers,
                                          const byte* data,
@@ -19,7 +19,7 @@ namespace tempearly
         {
             Utils::ParseQueryString(query_string, m_parameters);
         }
-        if (m_method == "POST"
+        if (m_method == HttpMethod::POST
             && GetContentType() == "application/x-www-form-urlencoded"
             && GetContentLength() > 0)
         {
@@ -27,7 +27,7 @@ namespace tempearly
         }
     }
 
-    String HttpServerRequest::GetMethod() const
+    HttpMethod::Kind HttpServerRequest::GetMethod() const
     {
         return m_method;
     }

--- a/src/sapi/httpd/httpd-request.h
+++ b/src/sapi/httpd/httpd-request.h
@@ -12,13 +12,13 @@ namespace tempearly
     {
     public:
         explicit HttpServerRequest(const Handle<Socket>& socket,
-                                   const String& method,
+                                   HttpMethod::Kind method,
                                    const String& query_string,
                                    const Dictionary<String>& headers,
                                    const byte* data,
                                    std::size_t data_size);
 
-        String GetMethod() const;
+        HttpMethod::Kind GetMethod() const;
 
         bool HasParameter(const String& id) const;
 
@@ -36,7 +36,7 @@ namespace tempearly
 
     private:
         Socket* m_socket;
-        String m_method;
+        const HttpMethod::Kind m_method;
         Dictionary<String> m_headers;
         Dictionary<std::vector<String> > m_parameters;
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(HttpServerRequest);

--- a/src/sapi/request.h
+++ b/src/sapi/request.h
@@ -2,6 +2,7 @@
 #define TEMPERALY_SAPI_REQUEST_H_GUARD
 
 #include "memory.h"
+#include "http/method.h"
 
 namespace tempearly
 {
@@ -15,7 +16,7 @@ namespace tempearly
         /**
          * Returns request method (GET, POST, etc.).
          */
-        virtual String GetMethod() const = 0;
+        virtual HttpMethod::Kind GetMethod() const = 0;
 
         virtual bool HasParameter(const String& id) const = 0;
 


### PR DESCRIPTION
This will hopefully simplify things and most likely in future they are
required elsewhere.
