### PR TITLE
Caching in Filename class.

### DIFF
--- a/src/core/filename.h
+++ b/src/core/filename.h
@@ -2,6 +2,9 @@
 #define TEMPEARLY_CORE_FILENAME_H_GUARD
 
 #include "core/string.h"
+#if !defined(_WIN32)
+# include <sys/stat.h>
+#endif
 
 namespace tempearly
 {
@@ -103,10 +106,20 @@ namespace tempearly
             return Concat(string);
         }
 
+#if !defined(_WIN32)
+    private:
+        void Stat() const;
+#endif
+
     private:
         String m_filename;
         String m_root;
         std::vector<String> m_path;
+#if !defined(_WIN32)
+        mutable struct ::stat m_stat;
+        mutable bool m_stat_done;
+        mutable bool m_stat_succeeded;
+#endif
     };
 }
 

--- a/src/core/string.h
+++ b/src/core/string.h
@@ -1,6 +1,10 @@
 #ifndef TEMPEARLY_CORE_STRING_H_GUARD
 #define TEMPEARLY_CORE_STRING_H_GUARD
 
+#if defined(_WIN32)
+# include <string> // For std::wstring
+#endif
+
 #include "memory.h"
 
 namespace tempearly
@@ -123,6 +127,19 @@ namespace tempearly
          * Returns UTF-8 encoded form of the string.
          */
         ByteString Encode() const;
+
+#if defined(_WIN32)
+        /**
+         * Returns UTF-16LE version of the string which is suitable to be used
+         * for Windows API calls.
+         */
+        std::wstring Widen() const;
+
+        /**
+         * Narrows UTF-16LE encoded wide char string into Unicode string.
+         */
+        static String Narrow(const wchar_t* input);
+#endif
 
         /**
          * Calculates hash code for the string. This is usually done only once,

--- a/src/sapi/httpd/main.cc
+++ b/src/sapi/httpd/main.cc
@@ -1,5 +1,3 @@
-#include <sys/stat.h>
-
 #include "utils.h"
 #include "core/bytestring.h"
 #include "core/filename.h"

--- a/src/sapi/httpd/server.cc
+++ b/src/sapi/httpd/server.cc
@@ -1,8 +1,6 @@
 #include <cstring>
 #include <vector>
 
-#include <sys/stat.h>
-
 #include "interpreter.h"
 #include "core/filename.h"
 #include "core/bytestring.h"


### PR DESCRIPTION
1. Implement caching of `stat` function call in `Filename` class to
   reduce the number of calls to that function.
2. Add some Windows API related stuff in `String` class and `Filename`
   class, even if we don't support that platform yet.
3. Remove unncessary includes.
