### PR TITLE
Add return statement.

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -323,6 +323,35 @@ namespace tempearly
         return Result(Result::KIND_CONTINUE);
     }
 
+    ReturnNode::ReturnNode(const Handle<Node>& value)
+        : m_value(value.Get()) {}
+
+    Result ReturnNode::Execute(const Handle<Interpreter>& interpreter) const
+    {
+        if (m_value)
+        {
+            Value value = m_value->Evaluate(interpreter);
+
+            if (value)
+            {
+                return Result(Result::KIND_RETURN, value);
+            } else {
+                return Result(Result::KIND_ERROR);
+            }
+        }
+
+        return Result(Result::KIND_RETURN);
+    }
+
+    void ReturnNode::Mark()
+    {
+        Node::Mark();
+        if (m_value && !m_value->IsMarked())
+        {
+            m_value->Mark();
+        }
+    }
+
     ValueNode::ValueNode(const Value& value)
         : m_value(value) {}
 

--- a/src/node.h
+++ b/src/node.h
@@ -202,6 +202,20 @@ namespace tempearly
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(ContinueNode);
     };
 
+    class ReturnNode : public Node
+    {
+    public:
+        explicit ReturnNode(const Handle<Node>& value = Handle<Node>());
+
+        Result Execute(const Handle<Interpreter>& interpreter) const;
+
+        void Mark();
+
+    private:
+        Node* m_value;
+        TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(ReturnNode);
+    };
+
     class ValueNode : public Node
     {
     public:

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1248,7 +1248,22 @@ SCAN_EXPONENT:
                 node = new ContinueNode();
                 break;
 
-            //TODO:case Token::KW_RETURN:
+            case Token::KW_RETURN:
+            {
+                Handle<Node> value;
+
+                parser->SkipToken();
+                if (!parser->PeekToken(Token::SEMICOLON))
+                {
+                    if (!(value = parse_expr(interpreter, parser)))
+                    {
+                        return Handle<Node>();
+                    }
+                }
+                node = new ReturnNode(value);
+                break;
+            }
+
             //TODO:case Token::KW_THROW:
 
             default:

--- a/src/script.cc
+++ b/src/script.cc
@@ -29,9 +29,7 @@ namespace tempearly
                     break;
 
                 case Result::KIND_RETURN:
-                    interpreter->Throw(interpreter->eSyntaxError,
-                                       "Unexpected `return'");
-                    break;
+                    return true;
 
                 default:
                     break;


### PR DESCRIPTION
Adds `return` statement which can be used to return values from function
calls.

Also includes an idea that script execution can be broken with `return`
statement. If `return` statement is invoked in middle of script
execution, execution stops there and rest of the script is ignored. It
helps to create stuff like this:

```
<%
if request.is_ajax():
    response["Content-Type"] = "application/json";
    response.write("{\"foo\": \"bar\"}");
    return;
end if;
%>
<html>
<head>
    <title>blah blah</title>
```
