### PR TITLE
Add `import` function.

### DIFF
--- a/src/api/core.cc
+++ b/src/api/core.cc
@@ -1,30 +1,76 @@
 #include "interpreter.h"
-#include "core/filename.h"
+#include "api/file.h"
 
 namespace tempearly
 {
+    static bool value_to_file(const Handle<Interpreter>& interpreter, const Value& value, Filename& slot)
+    {
+        if (value.IsFile())
+        {
+            slot = value.As<FileObject>()->GetPath();
+
+            return true;
+        } else {
+            String string;
+
+            if (value.AsString(interpreter, string))
+            {
+                slot = string;
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+
     /**
      * include(filename)
      *
-     * Includes given filename into current script.
+     * Includes given file into current script.
      *
      * Throws: ImportError - If file cannot be included for some reason.
      */
     TEMPEARLY_NATIVE_METHOD(func_include)
     {
-        String filename;
+        Filename file;
 
-        if (!args[0].AsString(interpreter, filename)
-            || !interpreter->Include(Filename(filename)))
+        if (value_to_file(interpreter, args[0], file) && interpreter->Include(file))
         {
-            return Value();
-        } else {
             return Value::NewBool(true);
+        } else {
+            return Value();
+        }
+    }
+
+    /**
+     * import(filename) => Map
+     *
+     * Includes given file into current script and returns it's variable scope
+     * as hash map.
+     *
+     * Files are imported only once, their resulting variable scope is cached
+     * into the interpreter and the cached hash map is returned on subsequent
+     * import calls of the same file.
+     *
+     * This is usually used to import common utility functions declared in
+     * other files.
+     */
+    TEMPEARLY_NATIVE_METHOD(func_import)
+    {
+        Filename file;
+
+        if (value_to_file(interpreter, args[0], file))
+        {
+            return interpreter->Import(file);
+        } else {
+            return Value();
         }
     }
 
     void init_core(Interpreter* i)
     {
         i->AddFunction("include", 1, func_include);
+        i->AddFunction("import", 1, func_import);
     }
 }

--- a/src/api/map.h
+++ b/src/api/map.h
@@ -2,6 +2,7 @@
 #define TEMPEARLY_API_MAP_H_GUARD
 
 #include "value.h"
+#include "api/object.h"
 
 namespace tempearly
 {

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -13,9 +13,13 @@ namespace tempearly
     public:
         explicit Interpreter();
 
+        ~Interpreter();
+
         void Initialize();
 
         bool Include(const Filename& filename);
+
+        Value Import(const Filename& filename);
 
         Handle<Class> AddClass(const String& name,
                                const Handle<Class>& base);
@@ -133,6 +137,8 @@ namespace tempearly
         Handle<Scope> m_scope;
         /** Shared instance of empty iterator. */
         IteratorObject* m_empty_iterator;
+        /** Container for imported files. */
+        Dictionary<Value>* m_imported_files;
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(Interpreter);
     };
 }

--- a/src/scope.cc
+++ b/src/scope.cc
@@ -1,4 +1,5 @@
-#include "scope.h"
+#include "interpreter.h"
+#include "api/map.h"
 
 namespace tempearly
 {
@@ -44,6 +45,23 @@ namespace tempearly
             m_variables = new VariableMap();
         }
         m_variables->Insert(id, value);
+    }
+
+    Handle<MapObject> Scope::ToMap(const Handle<Interpreter>& interpreter) const
+    {
+        Handle<MapObject> map = new MapObject(interpreter->cMap);
+
+        if (m_variables)
+        {
+            for (const VariableMap::Entry* entry = m_variables->GetFront(); entry; entry = entry->GetNext())
+            {
+                const String& name = entry->GetName();
+
+                map->Insert(name.HashCode(), Value::NewString(name), entry->GetValue());
+            }
+        }
+
+        return map;
     }
 
     void Scope::Mark()

--- a/src/scope.h
+++ b/src/scope.h
@@ -61,6 +61,11 @@ namespace tempearly
          */
         void SetVariable(const String& id, const Value& value);
 
+        /**
+         * Constructs an hash map from contents of the variable scope.
+         */
+        Handle<MapObject> ToMap(const Handle<Interpreter>& interpreter) const;
+
         void Mark();
 
     private:


### PR DESCRIPTION
This commit adds an global `import` function which can be used to import
shit from other files.

Example of it's usage:

```
<%
    stuff_from_other_file = import("some_other_file.tly");

    response.write(stuff_from_other_file["variable_from_other_file"]);
%>
```

Files can only be imported once. The resulting hash map is cached into
the interpreter and that cached version is returned on subsequent import
calls of the same file.
