### PR TITLE
Add __getattr__ fallback.

### DIFF
--- a/src/api/core.cc
+++ b/src/api/core.cc
@@ -47,10 +47,10 @@ namespace tempearly
      * import(filename) => Map
      *
      * Includes given file into current script and returns it's variable scope
-     * as hash map.
+     * as an object.
      *
      * Files are imported only once, their resulting variable scope is cached
-     * into the interpreter and the cached hash map is returned on subsequent
+     * into the interpreter and the cached object is returned on subsequent
      * import calls of the same file.
      *
      * This is usually used to import common utility functions declared in

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -128,7 +128,7 @@ namespace tempearly
 
                 return Value();
             }
-            result = Value::NewObject(m_scope->ToMap(this));
+            result = m_scope->ToObject(this);
             PopScope();
             if (!m_imported_files)
             {

--- a/src/scope.cc
+++ b/src/scope.cc
@@ -1,5 +1,4 @@
 #include "interpreter.h"
-#include "api/map.h"
 
 namespace tempearly
 {
@@ -47,21 +46,19 @@ namespace tempearly
         m_variables->Insert(id, value);
     }
 
-    Handle<MapObject> Scope::ToMap(const Handle<Interpreter>& interpreter) const
+    Handle<Object> Scope::ToObject(const Handle<Interpreter>& interpreter) const
     {
-        Handle<MapObject> map = new MapObject(interpreter->cMap);
+        Handle<Object> object = new Object(interpreter->cObject);
 
         if (m_variables)
         {
             for (const VariableMap::Entry* entry = m_variables->GetFront(); entry; entry = entry->GetNext())
             {
-                const String& name = entry->GetName();
-
-                map->Insert(name.HashCode(), Value::NewString(name), entry->GetValue());
+                object->SetAttribute(entry->GetName(), entry->GetValue());
             }
         }
 
-        return map;
+        return object;
     }
 
     void Scope::Mark()

--- a/src/scope.h
+++ b/src/scope.h
@@ -62,9 +62,10 @@ namespace tempearly
         void SetVariable(const String& id, const Value& value);
 
         /**
-         * Constructs an hash map from contents of the variable scope.
+         * Constructs an object which contains variables from this scope as
+         * attributes.
          */
-        Handle<MapObject> ToMap(const Handle<Interpreter>& interpreter) const;
+        Handle<Object> ToObject(const Handle<Interpreter>& interpreter) const;
 
         void Mark();
 

--- a/src/value.h
+++ b/src/value.h
@@ -81,6 +81,11 @@ namespace tempearly
         Value& operator=(const Value& that);
 
         /**
+         * Assignment operator.
+         */
+        Value& operator=(const Handle<CoreObject>& object);
+
+        /**
          * Returns kind of the value.
          */
         inline Kind GetKind() const


### PR DESCRIPTION
Adds an `__getattr__` fallback similiar in Python to objects/values. When
an attribute is looked for which does not exist, and the object has an
function named `__getattr__`, that function is invoked and value
returned by it used as the value of the attribute. If `__getattr__` does
not exist, an exception is thrown.

Secondly, modifies `import` function so that it returns an regular
object instead of hash map.
