### PR TITLE
Unify SendException method in Response class.

### DIFF
--- a/src/sapi/apache/response.cc
+++ b/src/sapi/apache/response.cc
@@ -1,7 +1,6 @@
 #include <http_protocol.h>
 #include <apr_strings.h>
 
-#include "api/exception.h"
 #include "core/bytestring.h"
 #include "sapi/apache/response.h"
 
@@ -52,29 +51,5 @@ namespace tempearly
             Commit();
         }
         ap_rwrite(data, size, m_request);
-    }
-
-    void ApacheResponse::SendException(const Handle<ExceptionObject>& exception)
-    {
-        if (!exception)
-        {
-            return; // Just in case
-        }
-        if (m_committed)
-        {
-            ap_rprintf(
-                m_request,
-                "<p><strong>ERROR:</strong> %s</p>",
-                exception->GetMessage().Encode().c_str()
-            );
-        } else {
-            m_committed = true;
-            ap_set_content_type(m_request, "text/plain");
-            ap_rprintf(
-                m_request,
-                "ERROR:\n%s\n",
-                exception->GetMessage().Encode().c_str()
-            );
-        }
     }
 }

--- a/src/sapi/apache/response.h
+++ b/src/sapi/apache/response.h
@@ -18,8 +18,6 @@ namespace tempearly
 
         void Write(std::size_t size, const char* data);
 
-        void SendException(const Handle<ExceptionObject>& exception);
-
     private:
         request_rec* m_request;
         bool m_committed;

--- a/src/sapi/cgi/response.cc
+++ b/src/sapi/cgi/response.cc
@@ -1,4 +1,3 @@
-#include "api/exception.h"
 #include "core/bytestring.h"
 #include "sapi/cgi/response.h"
 
@@ -44,33 +43,5 @@ namespace tempearly
                     sizeof(char),
                     size,
                     stdout);
-    }
-
-    void CgiResponse::SendException(const Handle<ExceptionObject>& exception)
-    {
-        if (!exception)
-        {
-            return; // Just in case.
-        }
-        if (m_committed)
-        {
-            std::fprintf(
-                stdout,
-                "<p><strong>ERROR:</strong> %s</p>",
-                exception->GetMessage().Encode().c_str()
-            );
-        } else {
-            m_committed = true;
-            std::fprintf(
-                stdout,
-                "Status: 500\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n"
-            );
-            std::fprintf(
-                stdout,
-                "ERROR:\n%s\n",
-                exception->GetMessage().Encode().c_str()
-            );
-            std::fflush(stdout);
-        }
     }
 }

--- a/src/sapi/cgi/response.h
+++ b/src/sapi/cgi/response.h
@@ -16,8 +16,6 @@ namespace tempearly
 
         void Write(std::size_t size, const char* data);
 
-        void SendException(const Handle<ExceptionObject>& exception);
-
     private:
         /** Whether the response has been committed or not. */
         bool m_committed;

--- a/src/sapi/httpd/response.cc
+++ b/src/sapi/httpd/response.cc
@@ -40,28 +40,6 @@ namespace tempearly
         m_socket->Send(data, size);
     }
 
-    void HttpServerResponse::SendException(const Handle<ExceptionObject>& exception)
-    {
-        if (!exception)
-        {
-            return; // Just in case.
-        }
-        if (m_committed)
-        {
-            m_socket->Printf(
-                "<p><strong>ERROR:</strong> %s</p>",
-                exception->GetMessage().Encode().c_str()
-            );
-        } else {
-            m_committed = true;
-            m_socket->Printf("HTTP/1.0 500 Internal Server Error\r\n");
-            m_socket->Printf("Content-Type: text/plain; charset=utf-8\r\n\r\n");
-            m_socket->Printf("ERROR:\n%s\n",
-                             exception->GetMessage().Encode().c_str());
-            // TODO: flush socket
-        }
-    }
-
     void HttpServerResponse::Mark()
     {
         Response::Mark();

--- a/src/sapi/httpd/response.h
+++ b/src/sapi/httpd/response.h
@@ -18,8 +18,6 @@ namespace tempearly
 
         void Write(std::size_t size, const char* data);
 
-        void SendException(const Handle<ExceptionObject>& exception);
-
         void Mark();
 
     private:

--- a/src/sapi/response.cc
+++ b/src/sapi/response.cc
@@ -1,3 +1,5 @@
+#include "utils.h"
+#include "api/exception.h"
 #include "core/bytestring.h"
 #include "sapi/response.h"
 
@@ -52,5 +54,22 @@ namespace tempearly
         const ByteString bytes = string.Encode();
 
         Write(bytes.GetLength(), bytes.c_str());
+    }
+
+    void Response::SendException(const Handle<ExceptionObject>& exception)
+    {
+        if (!exception)
+        {
+            return; // Just in case
+        }
+        else if (IsCommitted())
+        {
+            Write("\n<p><strong>ERROR:</strong> " + Utils::XmlEscape(exception->GetMessage()) + "</p>\n");
+        } else {
+            m_headers.Clear();
+            SetHeader("Content-Type", "text/plain; charset=utf-8");
+            m_status = 500;
+            Write("ERROR:\n" + exception->GetMessage() + "\n");
+        }
     }
 }

--- a/src/sapi/response.h
+++ b/src/sapi/response.h
@@ -80,7 +80,7 @@ namespace tempearly
 
         virtual void Write(std::size_t size, const char* data) = 0;
 
-        virtual void SendException(const Handle<ExceptionObject>& exception) = 0;
+        void SendException(const Handle<ExceptionObject>& exception);
 
     private:
         /** Status code of the response. */


### PR DESCRIPTION
Provides a common implementation of `SendException` method in `Response`
class so that all SAPI implementations do not require their own
implementation of it, which is easier to maintain in future.
