### PR TITLE
Replace C file streams with POSIX handles.

### DIFF
--- a/src/core/filename.h
+++ b/src/core/filename.h
@@ -12,6 +12,13 @@ namespace tempearly
     class Filename
     {
     public:
+        enum OpenMode
+        {
+            MODE_READ,
+            MODE_WRITE,
+            MODE_READ_WRITE
+        };
+
         /**
          * Platform specific filename separator.
          */
@@ -190,15 +197,17 @@ namespace tempearly
         DateTime GetLastModified() const;
 
         /**
-         * Passes filename into std::fopen and returns resulting file handle.
+         * Opens file which the file name represents and returns it as a
+         * stream.
          *
-         * \param mode Open mode, see manual page for std::fopen for more
-         *             details
-         * \return     Pointer to file handle which can be used to read/write
-         *             contents of the file, or NULL if file cannot be opened
-         *             for some reason
+         * \param mode   In which mode the file should be opened
+         * \param append Whether existing files should be appended instead of
+         *               overwritten when opening for writing
+         * \return       Pointer to file handle which can be used to read/write
+         *               contents of the file, or NULL if file cannot be opened
+         *               for some reason
          */
-        Handle<Stream> Open(const String& mode) const;
+        Handle<Stream> Open(OpenMode mode, bool append = false) const;
 
         /**
          * Returns true if filename is equal with another filename.

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -81,7 +81,7 @@ namespace tempearly
 
     bool Interpreter::Include(const Filename& filename)
     {
-        Handle<Stream> stream = filename.Open("rb");
+        Handle<Stream> stream = filename.Open(Filename::MODE_READ);
 
         if (stream)
         {
@@ -122,7 +122,7 @@ namespace tempearly
                 return entry->GetValue();
             }
         }
-        if ((stream = filename.Open("rb")))
+        if ((stream = filename.Open(Filename::MODE_READ)))
         {
             Handle<Parser> parser = new Parser(stream);
             Handle<Script> script = parser->Compile();

--- a/src/sapi/fastcgi/main.cc
+++ b/src/sapi/fastcgi/main.cc
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
 
 static Handle<Script> compile_script(const Filename& filename, String& error_message)
 {
-    Handle<Stream> stream = filename.Open("rb");
+    Handle<Stream> stream = filename.Open(Filename::MODE_READ);
 
     if (stream)
     {

--- a/src/sapi/httpd/server.cc
+++ b/src/sapi/httpd/server.cc
@@ -152,7 +152,7 @@ namespace tempearly
                                const Filename& path,
                                const String& mime_type)
     {
-        Handle<Stream> stream = path.Open("rb");
+        Handle<Stream> stream = path.Open(Filename::MODE_READ);
 
         if (stream)
         {
@@ -411,7 +411,7 @@ namespace tempearly
 
     static void compile_script(HttpServer::ScriptMapping& mapping)
     {
-        Handle<Stream> stream = mapping.filename.Open("rb");
+        Handle<Stream> stream = mapping.filename.Open(Filename::MODE_READ);
 
         if (stream)
         {


### PR DESCRIPTION
This gives us access to unbuffered streams, allowing us to implement our
own buffering with `Stream` class later. Also in theory a minor
performance boost when reading files or writing into files should occur
with this.

Downside is that there is currently no Windows implementation for file
I/O but that shouldn't be a problem yet since we don't support that
platform yet. It should be somewhat easy task to implement file I/O on
Windows platform with it's own API. More details on that can be found
at:
http://msdn.microsoft.com/en-us/library/windows/desktop/bb540534%28v=vs.85%29.aspx
