### PR TITLE
API: Get rid of the comparison operator.

### DIFF
--- a/src/api/binary.cc
+++ b/src/api/binary.cc
@@ -311,18 +311,46 @@ namespace tempearly
     }
 
     /**
-     * Binary#__cmp__(other) => Int
+     * Binary#__eq__(other) => Bool
      *
-     * Compares two binary datas lexicographically.
+     * Tests whether two binary objects are equal.
      */
-    TEMPEARLY_NATIVE_METHOD(bin_cmp)
+    TEMPEARLY_NATIVE_METHOD(bin_eq)
     {
-        if (args[1].IsBinary())
+        const Value& self = args[0];
+        const Value& operand = args[1];
+
+        if (operand.IsBinary())
         {
-            return Value::NewInt(args[0].AsBinary().Compare(args[1].AsBinary()));
+            return Value::NewBool(self.AsBinary().Equals(operand.AsBinary()));
         } else {
-            return Value::NullValue();
+            return Value::NewBool(false);
         }
+    }
+
+    /**
+     * Binary#__lt__(other) => Bool
+     *
+     * Compares two binary datas lexicographically and returns true if receiving
+     * value is less than value given as argument.
+     *
+     * Throws: TypeError - If other object is not instance of Binary.
+     */
+    TEMPEARLY_NATIVE_METHOD(bin_lt)
+    {
+        const Value& self = args[0];
+        const Value& operand = args[1];
+
+        if (operand.IsBinary())
+        {
+            return Value::NewBool(self.AsBinary().Compare(operand.AsBinary()) < 0);
+        }
+        interpreter->Throw(
+            interpreter->eTypeError,
+            "Cannot compare '" + operand.GetClass(interpreter)->GetName() + "' with 'Binary'"
+        );
+
+        return Value();
     }
 
     /**
@@ -423,7 +451,8 @@ namespace tempearly
         // Operators
         i->cBinary->AddMethod(i, "__add__", 1, bin_add);
         i->cBinary->AddMethod(i, "__mul__", 1, bin_mul);
-        i->cBinary->AddMethod(i, "__cmp__", 1, bin_cmp);
+        i->cBinary->AddMethod(i, "__eq__", 1, bin_eq);
+        i->cBinary->AddMethod(i, "__lt__", 1, bin_lt);
         i->cBinary->AddMethod(i, "__getitem__", 1, bin_getitem);
 
         i->cBinary->AddMethodAlias(i, "__str__", "join");

--- a/src/api/file.cc
+++ b/src/api/file.cc
@@ -367,21 +367,22 @@ namespace tempearly
     }
 
     /**
-     * File#__cmp__(other) => Int
+     * File#__eq__(other) => Bool
      *
-     * Compares two filenames lexicographically against each other.
+     * Compares two filenames lexicographically against each other and returns
+     * true if they are equal.
      */
-    TEMPEARLY_NATIVE_METHOD(file_cmp)
+    TEMPEARLY_NATIVE_METHOD(file_eq)
     {
-        if (args[1].IsFile())
+        const Value& self = args[0];
+        const Value& operand = args[1];
+
+        if (operand.IsFile())
         {
-            const Filename a = args[0].As<FileObject>()->GetPath();
-            const Filename b = args[1].As<FileObject>()->GetPath();
-
-            return Value::NewInt(a.Compare(b));
+            return Value::NewBool(self.As<FileObject>()->GetPath().Equals(operand.As<FileObject>()->GetPath()));
+        } else {
+            return Value::NewBool(false);
         }
-
-        return Value::NullValue();
     }
 
     /**
@@ -417,7 +418,7 @@ namespace tempearly
         i->cFile->AddMethod(i, "__iter__", 0, file_iter);
 
         // Operators
-        i->cFile->AddMethod(i, "__cmp__", 1, file_cmp);
+        i->cFile->AddMethod(i, "__eq__", 1, file_eq);
 
         // Conversion methods
         i->cFile->AddMethod(i, "__str__", 0, file_str);

--- a/src/api/iterable.cc
+++ b/src/api/iterable.cc
@@ -776,7 +776,7 @@ namespace tempearly
         std::size_t left;
         std::size_t right;
         std::size_t pivot;
-        int cmp;
+        bool slot;
 
         if (slice_size < 2)
         {
@@ -796,17 +796,17 @@ namespace tempearly
 
         while (left < right)
         {
-            if (!vector[left].Compare(interpreter, vector[pivot], cmp))
+            if (!vector[pivot].IsLessThan(interpreter, vector[left], slot))
             {
                 return false;
             }
-            else if (cmp > 0)
+            else if (slot)
             {
-                if (!vector[right].Compare(interpreter, vector[pivot], cmp))
+                if (!vector[right].IsLessThan(interpreter, vector[pivot], slot))
                 {
                     return false;
                 }
-                else if (cmp < 0)
+                else if (slot)
                 {
                     vector.Swap(left++, right--);
                 } else {
@@ -821,11 +821,11 @@ namespace tempearly
 
         while (left - offset < slice_size - 1)
         {
-            if (!vector[pivot].Compare(interpreter, vector[left], cmp))
+            if (!vector[pivot].IsLessThan(interpreter, vector[left], slot))
             {
                 return false;
             }
-            else if (cmp < 0)
+            else if (slot)
             {
                 vector.Swap(pivot, left);
                 break;
@@ -849,7 +849,7 @@ namespace tempearly
         std::size_t pivot;
         Vector<Value> args;
         Value result;
-        i64 cmp;
+        bool slot;
 
         if (slice_size < 2)
         {
@@ -873,20 +873,20 @@ namespace tempearly
             args.Clear();
             args.PushBack(vector[left]);
             args.PushBack(vector[pivot]);
-            if (!(result = function.Call(interpreter, "__call__", args)) || !result.AsInt(interpreter, cmp))
+            if (!(result = function.Call(interpreter, "__call__", args)) || !result.AsBool(interpreter, slot))
             {
                 return false;
             }
-            else if (cmp > 0)
+            else if (!slot)
             {
                 args.Clear();
                 args.PushBack(vector[right]);
                 args.PushBack(vector[pivot]);
-                if (!(result = function.Call(interpreter, "__call__", args)) || !result.AsInt(interpreter, cmp))
+                if (!(result = function.Call(interpreter, "__call__", args)) || !result.AsBool(interpreter, slot))
                 {
                     return false;
                 }
-                else if (cmp < 0)
+                else if (slot)
                 {
                     vector.Swap(left++, right--);
                 } else {
@@ -904,11 +904,11 @@ namespace tempearly
             args.Clear();
             args.PushBack(vector[pivot]);
             args.PushBack(vector[left]);
-            if (!(result = function.Call(interpreter, "__call__", args)) || !result.AsInt(interpreter, cmp))
+            if (!(result = function.Call(interpreter, "__call__", args)) || !result.AsBool(interpreter, slot))
             {
                 return false;
             }
-            else if (cmp < 0)
+            else if (slot)
             {
                 vector.Swap(pivot, left);
                 break;
@@ -925,8 +925,8 @@ namespace tempearly
      * Iterable#sort([function(element1, element2)]) => List
      *
      * Creates a list which has all elements from the iteration in order sorted
-     * by the "__cmp__" method. An optional function can be given as argument
-     * which is used for comparison instead of the "__cmp__" method.
+     * with the "__lt__" method. An optional function can be given as argument
+     * which is used for comparison instead of the "__lt__" method.
      *
      *     [3, 2, 1].sort();    #=> [1, 2, 3]
      */

--- a/src/api/number.cc
+++ b/src/api/number.cc
@@ -303,31 +303,56 @@ namespace tempearly
     }
 
     /**
-     * Int#__cmp__(other) => Int
+     * Int#__eq__(other) => Bool
      *
-     * Compares two numbers against each other.
+     * Compares two numbers against each other and returns true if they are
+     * equal.
      */
-    TEMPEARLY_NATIVE_METHOD(int_cmp)
+    TEMPEARLY_NATIVE_METHOD(int_eq)
     {
         const Value& self = args[0];
         const Value& operand = args[1];
 
         if (operand.IsInt())
         {
-            const i64 a = self.AsInt();
-            const i64 b = operand.AsInt();
-
-            return Value::NewInt(a > b ? 1 : a < b ? -1 : 0);
+            return Value::NewBool(self.AsInt() == operand.AsInt());
         }
         else if (operand.IsFloat())
         {
-            const double a = static_cast<double>(self.AsInt());
-            const double b = operand.AsFloat();
-
-            return Value::NewInt(a > b ? 1 : a < b ? -1 : 0);
+            return Value::NewBool(static_cast<double>(self.AsFloat()) == operand.AsFloat());
+        } else {
+            return Value::NewBool(false);
         }
+    }
 
-        return Value::NullValue();
+    /**
+     * Int#__lt__(other) => Bool
+     *
+     * Compares two numbers against each other and returns true if receiving
+     * number is less than the number given as argument.
+     *
+     * Throws: TypeError - If value given as argument is not integer or
+     * floating point number.
+     */
+    TEMPEARLY_NATIVE_METHOD(int_lt)
+    {
+        const Value& self = args[0];
+        const Value& operand = args[1];
+
+        if (operand.IsInt())
+        {
+            return Value::NewBool(self.AsInt() < operand.AsInt());
+        }
+        else if (operand.IsFloat())
+        {
+            return Value::NewBool(static_cast<double>(self.AsInt()) < operand.AsFloat());
+        }
+        interpreter->Throw(
+            interpreter->eTypeError,
+            "Cannot compare '" + operand.GetClass(interpreter)->GetName() + "' with 'Int'"
+        );
+
+        return Value();
     }
 
     /**
@@ -522,24 +547,46 @@ namespace tempearly
     }
 
     /**
-     * Float#__cmp__(other) => Int
+     * Float#__eq__(other) => Bool
      *
-     * Compares two numbers against each other.
+     * Compares two numbers against each other and returns true if they are
+     * equal.
      */
-    TEMPEARLY_NATIVE_METHOD(flo_cmp)
+    TEMPEARLY_NATIVE_METHOD(flo_eq)
     {
         const Value& operand = args[1];
-        const double a = args[0].AsFloat();
-        double b;
 
         if (operand.IsFloat() || operand.IsInt())
         {
-            b = operand.AsFloat();
+            return Value::NewBool(args[0].AsFloat() == operand.AsFloat());
         } else {
-            return Value::NullValue();
+            return Value::NewBool(false);
         }
+    }
 
-        return Value::NewInt(a > b ? 1 : a < b ? -1 : 0);
+    /**
+     * Float#__lt__(other) => Bool
+     *
+     * Compares two numbers against each other and returns true if receiving
+     * number is less than the number given as argument.
+     *
+     * Throws: TypeError - If value given as argument is not integer or
+     * floating point number.
+     */
+    TEMPEARLY_NATIVE_METHOD(flo_lt)
+    {
+        const Value& operand = args[1];
+
+        if (operand.IsFloat() || operand.IsInt())
+        {
+            return Value::NewBool(args[0].AsFloat() < operand.AsFloat());
+        }
+        interpreter->Throw(
+            interpreter->eTypeError,
+            "Cannot compare '" + operand.GetClass(interpreter)->GetName() + "' with 'Float'"
+        );
+
+        return Value();
     }
 
     /**
@@ -593,7 +640,8 @@ namespace tempearly
         i->cInt->AddMethod(i, "__xor__", 1, int_xor);
         i->cInt->AddMethod(i, "__lsh__", 1, int_lsh);
         i->cInt->AddMethod(i, "__rsh__", 1, int_rsh);
-        i->cInt->AddMethod(i, "__cmp__", 1, int_cmp);
+        i->cInt->AddMethod(i, "__eq__", 1, int_eq);
+        i->cInt->AddMethod(i, "__lt__", 1, int_lt);
         i->cInt->AddMethod(i, "__inc__", 0, int_inc);
         i->cInt->AddMethod(i, "__dec__", 0, int_dec);
         i->cInt->AddMethod(i, "__neg__", 0, int_neg);
@@ -611,7 +659,8 @@ namespace tempearly
         i->cFloat->AddMethod(i, "__mul__", 1, flo_mul);
         i->cFloat->AddMethod(i, "__div__", 1, flo_div);
         i->cFloat->AddMethod(i, "__mod__", 1, flo_mod);
-        i->cFloat->AddMethod(i, "__cmp__", 1, flo_cmp);
+        i->cFloat->AddMethod(i, "__eq__", 1, flo_eq);
+        i->cFloat->AddMethod(i, "__lt__", 1, flo_lt);
         i->cFloat->AddMethod(i, "__inc__", 0, flo_inc);
         i->cFloat->AddMethod(i, "__dec__", 0, flo_dec);
         i->cFloat->AddMethod(i, "__neg__", 0, flo_neg);

--- a/src/api/string.cc
+++ b/src/api/string.cc
@@ -620,23 +620,46 @@ namespace tempearly
     }
 
     /**
-     * String#__cmp__(other) => Int
+     * String#__eq__(other) => Bool
      *
-     * Compares two strings lexicographically against each other.
+     * Compares two strings against each other and returns true if they are
+     * equal.
      */
-    TEMPEARLY_NATIVE_METHOD(str_cmp)
+    TEMPEARLY_NATIVE_METHOD(str_eq)
     {
+        const Value& self = args[0];
         const Value& operand = args[1];
 
         if (operand.IsString())
         {
-            const String& a = args[0].AsString();
-            const String& b = operand.AsString();
-
-            return Value::NewInt(a.Compare(b));
+            return Value::NewBool(self.AsString().Equals(operand.AsString()));
+        } else {
+            return Value::NewBool(false);
         }
-        interpreter->Throw(interpreter->eTypeError,
-                           "Values are not comparable");
+    }
+
+    /**
+     * String#__lt__(other) => Bool
+     *
+     * Compares two strings lexicographically against each other and returns
+     * true if receiving value is less than value given as argument.
+     *
+     * Throws: TypeError - If value given as argument is not instance of
+     * String.
+     */
+    TEMPEARLY_NATIVE_METHOD(str_lt)
+    {
+        const Value& self = args[0];
+        const Value& operand = args[1];
+
+        if (operand.IsString())
+        {
+            return Value::NewBool(self.AsString().Compare(operand.AsString()) < 0);
+        }
+        interpreter->Throw(
+            interpreter->eTypeError,
+            "Cannot compare '" + operand.GetClass(interpreter)->GetName() + "' with 'String'"
+        );
 
         return Value();
     }
@@ -675,6 +698,7 @@ namespace tempearly
         // Operators.
         i->cString->AddMethod(i, "__add__", 1, str_add);
         i->cString->AddMethod(i, "__mul__", 1, str_mul);
-        i->cString->AddMethod(i, "__cmp__", 1, str_cmp);
+        i->cString->AddMethod(i, "__eq__", 1, str_eq);
+        i->cString->AddMethod(i, "__lt__", 1, str_lt);
     }
 }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -483,12 +483,7 @@ READ_NEXT_CHAR:
                 }
                 else if (ReadChar('='))
                 {
-                    if (ReadChar('>'))
-                    {
-                        token.kind = Token::CMP;
-                    } else {
-                        token.kind = Token::LTE;
-                    }
+                    token.kind = Token::LTE;
                 } else {
                     token.kind = Token::LT;
                 }
@@ -2025,7 +2020,6 @@ SCAN_EXPONENT:
             {
                 case Token::EQ:
                 case Token::MATCH:
-                case Token::CMP:
                 {
                     const Token::Kind kind = token.kind;
                     Handle<Node> operand;
@@ -2037,9 +2031,7 @@ SCAN_EXPONENT:
                     }
                     node = new CallNode(
                         node,
-                        kind == Token::EQ    ? "__eq__"    :
-                        kind == Token::MATCH ? "__match__" :
-                                               "__cmp__",
+                        kind == Token::EQ ? "__eq__" : "__match__",
                         Vector<Handle<Node> >(1, operand)
                     );
                     break;

--- a/src/token.cc
+++ b/src/token.cc
@@ -57,7 +57,6 @@ namespace tempearly
             case GT: return "`>'";
             case LTE: return "`<='";
             case GTE: return "`>='";
-            case CMP: return "`<=>'";
             case MATCH: return "`=~'";
             case NO_MATCH: return "`!~'";
 

--- a/src/token.h
+++ b/src/token.h
@@ -65,7 +65,6 @@ namespace tempearly
             GT,
             LTE,
             GTE,
-            CMP,
             MATCH,
             NO_MATCH,
 

--- a/src/value.cc
+++ b/src/value.cc
@@ -356,29 +356,22 @@ namespace tempearly
         return true;
     }
 
-    bool Value::Compare(const Handle<Interpreter>& interpreter, const Value& that, int& slot) const
+    bool Value::IsLessThan(const Handle<Interpreter>& interpreter, const Value& that, bool& slot) const
     {
-        Value result = Call(interpreter, "__cmp__", that);
+        Value result = Call(interpreter, "__lt__", that);
 
-        if (result)
+        if (!result)
         {
-            if (result.IsNull())
-            {
-                slot = 0;
-            } else {
-                i64 i;
-
-                if (!result.AsInt(interpreter, i))
-                {
-                    return false;
-                }
-                slot = static_cast<int>(i);
-            }
-
-            return true;
+            return false;
+        }
+        else if (result.IsBool())
+        {
+            slot = result.AsBool();
+        } else {
+            slot = false;
         }
 
-        return false;
+        return true;
     }
 
     bool Value::GetNext(const Handle<Interpreter>& interpreter, Value& slot) const

--- a/src/value.h
+++ b/src/value.h
@@ -225,8 +225,9 @@ namespace tempearly
         bool Equals(const Handle<Interpreter>& interpreter, const Value& that, bool& slot) const;
 
         /**
-         * Compares two values against each other. This is done by invoking the
-         * "__cmp__" method with given value as argument.
+         * Compares two values against each other using "__lt__" method and
+         * assigns <code>true</code> to <em>slot</em> if this value is less
+         * than the value given as argument.
          *
          * \param interpreter Script interpreter
          * \param that        Other value to compare this one against
@@ -235,7 +236,7 @@ namespace tempearly
          *                    was successfull or whether an exception was
          *                    thrown
          */
-        bool Compare(const Handle<Interpreter>& interpreter, const Value& that, int& slot) const;
+        bool IsLessThan(const Handle<Interpreter>& interpreter, const Value& that, bool& slot) const;
 
         /**
          * Treats object as iterator and attempts to retrieve it's next value.


### PR DESCRIPTION
Inspired by [API changes in Python 3](https://docs.python.org/3/whatsnew/3.0.html#ordering-comparisons), I got rid of the comparison
operator and `__cmp__` magic method. You can achieve same functionality
with `__eq__` and `__lt__` methods, but with less clutter and
ackwardness.
