### PR TITLE
Implement buffered streams.

### DIFF
--- a/src/core/filename.cc
+++ b/src/core/filename.cc
@@ -263,7 +263,8 @@ namespace tempearly
         {
         public:
             explicit PosixFileStream(Filename::OpenMode mode, int handle)
-                : m_mode(mode)
+                : Stream(mode == Filename::MODE_WRITE ? 0 : Stream::kBufferSize)
+                , m_mode(mode)
                 , m_handle(handle) {}
 
             ~PosixFileStream()
@@ -298,7 +299,7 @@ namespace tempearly
                 }
             }
 
-            bool ReadData(byte* buffer, std::size_t size, std::size_t& read)
+            bool DirectRead(byte* buffer, std::size_t size, std::size_t& read)
             {
                 if (m_handle >= 0)
                 {
@@ -319,7 +320,7 @@ namespace tempearly
                 return false;
             }
 
-            bool WriteData(const byte* data, std::size_t size)
+            bool DirectWrite(const byte* data, std::size_t size)
             {
                 if (m_handle >= 0)
                 {

--- a/src/io/stream.h
+++ b/src/io/stream.h
@@ -5,10 +5,26 @@
 
 namespace tempearly
 {
+    /**
+     * Abstract class for implementing buffered streams with a line counter.
+     */
     class Stream : public CountedObject
     {
     public:
-        explicit Stream();
+        /** Default buffer size. */
+        static const std::size_t kBufferSize;
+
+        /**
+         * Constructor for the abstract Stream class.
+         *
+         * \param buffer_size Size of the builtin buffer
+         */
+        explicit Stream(std::size_t buffer_size = kBufferSize);
+
+        /**
+         * This destructor destroys the buffer but does not close the stream.
+         */
+        virtual ~Stream();
 
         /**
          * Returns true if the stream has an error message.
@@ -18,39 +34,162 @@ namespace tempearly
             return !m_error_message.IsEmpty();
         }
 
+        /**
+         * Returns the error message of the stream, or empty string if this
+         * stream has no error.
+         */
         inline const String& GetErrorMessage() const
         {
             return m_error_message;
         }
 
+        /**
+         * Sets the error message of the stream.
+         */
         inline void SetErrorMessage(const String& error_message)
         {
             m_error_message = error_message;
         }
 
+        /**
+         * Returns current line number.
+         */
+        inline int GetLine() const
+        {
+            return m_line;
+        }
+
+        /**
+         * Sets the current line number.
+         *
+         * \param line New line number
+         */
+        inline void SetLine(int line)
+        {
+            m_line = line;
+        }
+
+        /**
+         * Returns <code>true</code> if the stream is open.
+         */
         virtual bool IsOpen() const = 0;
 
+        /**
+         * Returns <code>true</code> if data can be read from the stream.
+         */
         virtual bool IsReadable() const = 0;
 
+        /**
+         * Returns <code>true</code> if data can be written into the stream.
+         */
         virtual bool IsWritable() const = 0;
 
+        /**
+         * Closes the stream.
+         */
         virtual void Close() = 0;
 
-        virtual bool ReadData(byte* buffer, std::size_t size, std::size_t& read) = 0;
+        /**
+         * Flushes buffer of the stream.
+         */
+        void Flush();
 
+        /**
+         * Reads bytes directly from the stream, bypassing the stream buffer.
+         *
+         * \param buffer Array where the bytes will be stored into
+         * \param size   Number of bytes to read
+         * \param read   This is where the number of bytes successfully read
+         *               will be stored into
+         * \return       A boolean flag indicating whether the operation was
+         *               successfull or not
+         */
+        virtual bool DirectRead(byte* buffer, std::size_t size, std::size_t& read) = 0;
+
+        /**
+         * Reads bytes from the stream, using the builtin buffer functionality
+         * included within the class. This is the preferred way of input.
+         *
+         * \param buffer Array where the bytes will be stored into
+         * \param size   Number of bytes to read
+         * \param read   This is where the number of bytes successfully read
+         *               will be stored into
+         * \return       A boolean flag indicating whether the operation was
+         *               successfull or not
+         */
+        bool Read(byte* buffer, std::size_t size, std::size_t& read);
+
+        /**
+         * Reads a single UTF-8 encoded character from the stream.
+         *
+         * \param slot Where the resulting Unicode code point will be stored
+         *             into
+         * \return     A boolean flag indicating whether the operation was
+         *             successfull or not
+         */
         bool ReadRune(rune& slot);
 
-        virtual bool WriteData(const byte* data, std::size_t size) = 0;
+        /**
+         * Writes bytes directly to the stream, bypassing the stream buffer.
+         *
+         * \param data Array where the bytes are read from
+         * \param size Number of bytes to write
+         * \return     A boolean flag indicating whether the operation was
+         *             successfull or not
+         */
+        virtual bool DirectWrite(const byte* data, std::size_t size) = 0;
 
-        bool Write(const char* data, std::size_t size);
+        /**
+         * Writes bytes into the stream, using the builtin buffer functionality
+         * included within the class. This is the preferred way of output.
+         *
+         * \param data Array where the bytes are read from
+         * \param size Number of bytes to write
+         * \return     A boolean flag indicating whether the operation was
+         *             successfull or not
+         */
+        bool Write(const byte* data, std::size_t size);
 
+        /**
+         * Outputs bytes from given byte string into the stream.
+         *
+         * \param data Where the bytes will be read from
+         * \return     A boolean flag indicating whether the operation was
+         *             successfull or not
+         */
         bool Write(const ByteString& data);
 
+        /**
+         * Encodes given string into UTF-8 and outputs it into the stream.
+         *
+         * \param text String which is encoded into UTF-8 and written into the
+         *             stream
+         * \return     A boolean flag indicating whether the operation was
+         *             successfull or not
+         */
         bool Write(const String& text);
 
+        /**
+         * Outputs formatted text into the stream. See manual page of
+         * <code>printf</code> for more information about formatted strings.
+         *
+         * \return A boolean flag indicating whether the operation was
+         *         successfull or not
+         */
         bool Printf(const char* format, ...);
 
     private:
+        /** Size of the buffer. */
+        const std::size_t m_buffer_size;
+        /** Pointer to the actual buffer. */
+        byte* m_buffer;
+        /** Current offset of the buffer. */
+        std::size_t m_offset;
+        /** How many bytes are still unread from the buffer. */
+        std::size_t m_remain;
+        /** Current line number. */
+        int m_line;
+        /** Error message of the stream. */
         String m_error_message;
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(Stream);
     };

--- a/src/net/socket.cc
+++ b/src/net/socket.cc
@@ -8,7 +8,8 @@
 namespace tempearly
 {
     Socket::Socket()
-        : m_handle(-1) {}
+        : Stream(0)
+        , m_handle(-1) {}
 
     Socket::~Socket()
     {
@@ -43,7 +44,7 @@ namespace tempearly
         }
     }
 
-    bool Socket::ReadData(byte* buffer, std::size_t size, std::size_t& read)
+    bool Socket::DirectRead(byte* buffer, std::size_t size, std::size_t& read)
     {
         if (m_handle >= 0)
         {
@@ -66,7 +67,7 @@ namespace tempearly
         return false;
     }
 
-    bool Socket::WriteData(const byte* data, std::size_t size)
+    bool Socket::DirectWrite(const byte* data, std::size_t size)
     {
         if (m_handle >= 0)
         {

--- a/src/net/socket.h
+++ b/src/net/socket.h
@@ -33,9 +33,9 @@ namespace tempearly
 
         void Close();
 
-        bool ReadData(byte* buffer, std::size_t size, std::size_t& read);
+        bool DirectRead(byte* buffer, std::size_t size, std::size_t& read);
 
-        bool WriteData(const byte* data, std::size_t size);
+        bool DirectWrite(const byte* data, std::size_t size);
 
         bool Create(int port, int type, const String& host);
 

--- a/src/sapi/httpd/response.cc
+++ b/src/sapi/httpd/response.cc
@@ -28,7 +28,7 @@ namespace tempearly
                              entry->GetName().Encode().c_str(),
                              entry->GetValue().Encode().c_str());
         }
-        m_socket->Write("\r\n", 2);
+        m_socket->Write(reinterpret_cast<const byte*>("\r\n"), 2);
     }
 
     void HttpServerResponse::Write(std::size_t size, const char* data)
@@ -37,7 +37,7 @@ namespace tempearly
         {
             Commit();
         }
-        m_socket->Write(data, size);
+        m_socket->Write(reinterpret_cast<const byte*>(data), size);
     }
 
     void HttpServerResponse::Mark()

--- a/src/sapi/httpd/server.cc
+++ b/src/sapi/httpd/server.cc
@@ -85,7 +85,7 @@ namespace tempearly
         byte* data;
         Filename path;
 
-        if (!client->ReadData(buffer, HTTPD_MAX_REQUEST_SIZE, buffer_size))
+        if (!client->Read(buffer, HTTPD_MAX_REQUEST_SIZE, buffer_size))
         {
             client->Close();
             return;
@@ -163,9 +163,9 @@ namespace tempearly
                 byte buffer[4096];
                 std::size_t read;
 
-                while (stream->ReadData(buffer, sizeof(buffer), read))
+                while (stream->Read(buffer, sizeof(buffer), read))
                 {
-                    if (!client->WriteData(buffer, read))
+                    if (!client->Write(buffer, read))
                     {
                         break;
                     }


### PR DESCRIPTION
Adds buffering and line number counting to the abstract `Stream` class.

Currently it does not work well with sockets, especially in the builtin
HTTPD. Workaround for this is to disable buffering with sockets. Some
kind of socket timeout is possibly required for buffered sockets.
