### PR TITLE
Alternative syntax proposal.

### DIFF
--- a/examples/coin-flipper.tly
+++ b/examples/coin-flipper.tly
@@ -1,5 +1,5 @@
 #!/usr/bin/env tempearly-cgi
-<%
+{%
 if request.is_ajax():
     response["Content-Type"] = "application/json";
     if Bool.rand():
@@ -10,7 +10,7 @@ if request.is_ajax():
     response.write('{"image": "' + image + '"}');
     return;
 end if;
-%>
+%}
 <!DOCTYPE html>
 <html>
 <head>
@@ -33,7 +33,7 @@ end if;
             $("img").fadeOut(function()
             {
                 $.ajax({
-                    url: "${request.path()}",
+                    url: "{{request.path()}}",
                     success: function(data)
                     {
                         $("img").attr("src", data.image).fadeIn();

--- a/examples/form.tly
+++ b/examples/form.tly
@@ -9,11 +9,11 @@
 <body>
     <div class="container">
         <h1>Form test</h1>
-        <% if request.method() == "POST": %>
-            <p>Welcome $!request["name"]!</p>
-            <p>Your e-mail address is: $!request["email"]!</p>
-        <% else: %>
-            <form class="form-horizontal" method="post" action="$!request.path()!" role="form">
+        {% if request.method() == "POST": %}
+            <p>Welcome {{request["name"]}}</p>
+            <p>Your e-mail address is: {{request["email"]}}</p>
+        {% else: %}
+            <form class="form-horizontal" method="post" action="{{request.path()}}" role="form">
                 <div class="form-group">
                     <label for="name">Name:</label>
                     <input type="text" class="form-control" name="name" id="name" autofocus required>
@@ -24,7 +24,7 @@
                 </div>
                 <button type="submit" class="btn btn-lg btn-primary">Submit</button>
             </form>
-        <% end if %>
+        {% end if; %}
     </div>
 </body>
 </html>

--- a/examples/random.tly
+++ b/examples/random.tly
@@ -11,29 +11,29 @@
         <h2>Random integers</h2>
         <p>Int.rand():</p>
         <ul>
-        <% for i : 0..10: %>
-            <li>${Int.rand()}</li>
-        <% end for; %>
+        {% for i : 0..5: %}
+            <li>{{Int.rand()}}</li>
+        {% end for; %}
         </ul>
         <p>Int.rand(1000):</p>
         <ul>
-        <% for i : 0..10: %>
-            <li>${Int.rand(1000)}</li>
-        <% end for; %>
+        {% for i : 0..5: %}
+            <li>{{Int.rand(1000)}}</li>
+        {% end for; %}
         </ul>
 
         <h2>Random floats</h2>
         <p>Float.rand():</p>
         <ul>
-        <% for i : 0..10: %>
-            <li>${Float.rand()}</li>
-        <% end for; %>
+        {% for i : 0..5: %}
+            <li>{{Float.rand()}}</li>
+        {% end for; %}
         </ul>
         <p>Float.rand(1000):</p>
         <ul>
-        <% for i: 0..10: %>
-            <li>${Float.rand(1000)}</li>
-        <% end for; %>
+        {% for i: 0..5: %}
+            <li>{{Float.rand(1000)}}</li>
+        {% end for; %}
         </ul>
     </div>
 </body>

--- a/examples/sort.tly
+++ b/examples/sort.tly
@@ -9,11 +9,11 @@
 <body>
     <div class="container">
         <h2>Original list</h2>
-        <% list = (1..30).map(function(i) => Int.rand(1000)); %>
-        <p>${list}</p>
+        {% list = (1..30).map(function(i) => Int.rand(1000)); %}
+        <p>{{list}}</p>
 
         <h2>Sorted list</h2>
-        <p>${list.sort()}</p>
+        <p>{{list.sort()}}</p>
     </div>
 </body>
 </html>

--- a/src/token.cc
+++ b/src/token.cc
@@ -82,7 +82,7 @@ namespace tempearly
             case STRING: return "string literal";
             case INT:
             case FLOAT: return "number literal";
-            case CLOSE_TAG: return "`%>'";
+            case CLOSE_TAG: return "`%}'";
             case ERROR: return "error";
             case END_OF_INPUT: return "end of input";
         }


### PR DESCRIPTION
As discussed in issue #22, I am not happy with the current template
syntax. This commit modifies parser and examples for a new kind of
syntax, inspired by Jinja2 and Liquid templating engines.

New syntax in a nutshell:

```
{% code block %}

{{ escaped expression }}

{! unescaped (dangerous) expression !}

{# comment #}
```

Feel free to comment your opinion about this. If this completely sucks,
just close the PR.
