### PR TITLE
API: Add filtering/escaping methods to Object class.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ SET(
     src/api/core.cc
     src/api/exception.cc
     src/api/file.cc
+    src/api/filters.cc
     src/api/function.cc
     src/api/iterable.cc
     src/api/iterator.cc

--- a/src/api/filters.cc
+++ b/src/api/filters.cc
@@ -1,0 +1,47 @@
+#include "interpreter.h"
+
+namespace tempearly
+{
+    /**
+     * Object#escape_js() => String
+     *
+     * Converts object into string and escapes all characters which could cause
+     * problems when embedded into JavaScript string literal. Resulting string
+     * will be safe to use inside a JavaScript string literal.
+     */
+    TEMPEARLY_NATIVE_METHOD(obj_escape_js)
+    {
+        String string;
+
+        if (args[0].ToString(interpreter, string))
+        {
+            return Value::NewString(string.EscapeJavaScript());
+        } else {
+            return Value();
+        }
+    }
+
+    /**
+     * Object#escape_xml() => String
+     *
+     * Converts object into string and escapes all XML entities from it. The
+     * resulting string will be safe to use inside XML attribute or text node.
+     */
+    TEMPEARLY_NATIVE_METHOD(obj_escape_xml)
+    {
+        String string;
+
+        if (args[0].ToString(interpreter, string))
+        {
+            return Value::NewString(string.EscapeXml());
+        } else {
+            return Value();
+        }
+    }
+
+    void init_filters(Interpreter* i)
+    {
+        i->cObject->AddMethod(i, "escape_js", 0, obj_escape_js);
+        i->cObject->AddMethod(i, "escape_xml", 0, obj_escape_xml);
+    }
+}

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -16,6 +16,7 @@ namespace tempearly
     void init_core(Interpreter*);
     void init_exception(Interpreter*);
     void init_file(Interpreter*);
+    void init_filters(Interpreter*);
     void init_function(Interpreter*);
     void init_iterable(Interpreter*);
     void init_iterator(Interpreter*);
@@ -74,6 +75,7 @@ namespace tempearly
         init_file(this);
 
         init_core(this);
+        init_filters(this);
 
         init_request(this);
         init_response(this);


### PR DESCRIPTION
This commit adds two escaping/filtering methods to `Object` class. You
can convert any object to either XML or JavaScript escaped string. This
is done by converting the object into a string (if it's not a string
already) and then applying the escaping method on the resulting string.
