### PR TITLE
Use byte strings in various parts of the SAPI.

### DIFF
--- a/src/api/request.cc
+++ b/src/api/request.cc
@@ -23,6 +23,17 @@ namespace tempearly
     }
 
     /**
+     * Request#is_secure() => Bool
+     *
+     * Returns true if the request was made through a secure channel such as
+     * HTTPS.
+     */
+    TEMPEARLY_NATIVE_METHOD(req_is_secure)
+    {
+        return Value::NewBool(interpreter->request->IsSecure());
+    }
+
+    /**
      * Request#is_ajax() => Bool
      *
      * Returns true if the request was made with XMLHttpRequest or not. Notice
@@ -68,6 +79,7 @@ namespace tempearly
 
         cRequest->AddMethod(i, "method", 0, req_method);
         cRequest->AddMethod(i, "path", 0, req_path);
+        cRequest->AddMethod(i, "is_secure", 0, req_is_secure);
         cRequest->AddMethod(i, "is_ajax", 0, req_is_ajax);
 
         cRequest->AddMethod(i, "__getitem__", 1, req_getitem);

--- a/src/core/bytestring.cc
+++ b/src/core/bytestring.cc
@@ -72,6 +72,32 @@ namespace tempearly
         return *this;
     }
 
+    ByteString& ByteString::Assign(const char* input)
+    {
+        const std::size_t length = std::strlen(input);
+
+        if (--m_counter[0] == 0)
+        {
+            if (m_length != length)
+            {
+                Memory::Unallocate<byte>(m_bytes);
+                m_bytes = Memory::Allocate<byte>(length + 1);
+            }
+        } else {
+            m_bytes = Memory::Allocate<byte>(length + 1);
+            m_counter = Memory::Allocate<unsigned int>(1);
+        }
+        m_length = length;
+        m_counter[0] = 1;
+        for (std::size_t i = 0; i < length; ++i)
+        {
+            m_bytes[i] = static_cast<byte>(input[i]);
+        }
+        m_bytes[length] = 0;
+
+        return *this;
+    }
+
     bool ByteString::Equals(const ByteString& that) const
     {
         if (m_bytes == that.m_bytes)

--- a/src/core/bytestring.h
+++ b/src/core/bytestring.h
@@ -52,11 +52,26 @@ namespace tempearly
         ByteString& Assign(const ByteString& that);
 
         /**
+         * Copies contents from C type string.
+         *
+         * \param input String to copy bytes from
+         */
+        ByteString& Assign(const char* input);
+
+        /**
          * Assignment operator.
          */
         inline ByteString& operator=(const ByteString& that)
         {
             return Assign(that);
+        }
+
+        /**
+         * Assignment operator.
+         */
+        inline ByteString& operator=(const char* input)
+        {
+            return Assign(input);
         }
 
         /**

--- a/src/core/string.cc
+++ b/src/core/string.cc
@@ -194,6 +194,30 @@ namespace tempearly
         }
     }
 
+    String String::DecodeAscii(const byte* input)
+    {
+        return DecodeAscii(input, std::strlen(reinterpret_cast<const char*>(input)));
+    }
+
+    String String::DecodeAscii(const byte* input, std::size_t length)
+    {
+        String result;
+
+        if (length > 0)
+        {
+            result.m_length = length;
+            result.m_runes = Memory::Allocate<rune>(length);
+            result.m_counter = Memory::Allocate<unsigned int>(1);
+            result.m_counter[0] = 1;
+            for (std::size_t i = 0; i < length; ++i)
+            {
+                result.m_runes[i] = static_cast<rune>(input[i]);
+            }
+        }
+
+        return result;
+    }
+
     String& String::Assign(const String& that)
     {
         if (m_runes != that.m_runes)

--- a/src/core/string.h
+++ b/src/core/string.h
@@ -55,6 +55,23 @@ namespace tempearly
         ~String();
 
         /**
+         * Constructs string from bytes which are expected to be in US-ASCII
+         * character encoding.
+         *
+         * \param input  The bytes to decode, must be null terminated
+         */
+        static String DecodeAscii(const byte* input);
+
+        /**
+         * Constructs string from bytes which are expected to be in US-ASCII
+         * character encoding.
+         *
+         * \param input  The bytes to decode
+         * \param length Number of bytes contained in the array
+         */
+        static String DecodeAscii(const byte* input, std::size_t length);
+
+        /**
          * Copies contents of another string into this one.
          */
         String& Assign(const String& that);

--- a/src/net/url.h
+++ b/src/net/url.h
@@ -31,14 +31,25 @@ namespace tempearly
         Url(const Url& that);
 
         /**
-         * Attempts to decode URL entities from given string.
+         * Attempts to decode URL entities from given byte string.
          *
-         * \param input  String to decode
+         * \param input  Byte string to decode
          * \param output Where the resulting decoded string is assigned to
-         * \return       A boolean flag indicating whether decoding was
+         * \return       A boolean flag indicating whether the decoding was
          *               successfull or not
          */
-        static bool Decode(const String& input, String& output);
+        static bool Decode(const ByteString& input, String& output);
+
+        /**
+         * Attempts to decode URL entities from given byte input.
+         *
+         * \param input  Byte array where to extract data from
+         * \param length Size of the byte array
+         * \param output Where the resulting decoded string is assigned to
+         * \return       A boolean flag indicating whether the decoding was
+         *               successfull or not
+         */
+        static bool Decode(const byte* input, std::size_t length, String& output);
 
         /**
          * Encodes URL entities from the given string.

--- a/src/sapi/apache/request.cc
+++ b/src/sapi/apache/request.cc
@@ -1,6 +1,7 @@
 #include <cstring>
 
 #include "utils.h"
+#include "core/bytestring.h"
 #include "sapi/apache/request.h"
 
 namespace tempearly
@@ -24,6 +25,16 @@ namespace tempearly
     String ApacheRequest::GetPath() const
     {
         return m_request->uri;
+    }
+
+    bool ApacheRequest::IsSecure() const
+    {
+        if (m_request->server && m_request->server->server_scheme)
+        {
+            return !std::strcmp(m_request->server->server_scheme, "https");
+        } else {
+            return false;
+        }
     }
 
     bool ApacheRequest::IsAjax() const
@@ -73,7 +84,7 @@ namespace tempearly
         m_parameters_read = true;
         if (m_request->args && std::strlen(m_request->args) > 0)
         {
-            Utils::ParseQueryString(m_request->args, m_parameters);
+            Utils::ParseQueryString(ByteString(m_request->args), m_parameters);
         }
         if (m_method == HttpMethod::POST)
         {

--- a/src/sapi/apache/request.h
+++ b/src/sapi/apache/request.h
@@ -17,6 +17,8 @@ namespace tempearly
 
         String GetPath() const;
 
+        bool IsSecure() const;
+
         bool IsAjax() const;
 
         bool HasParameter(const String& id) const;

--- a/src/sapi/cgi/request.cc
+++ b/src/sapi/cgi/request.cc
@@ -9,11 +9,10 @@
 
 namespace tempearly
 {
+    static bool cgi_getenv_bin(const char*, ByteString&);
     static bool cgi_getenv_str(const char*, String&);
-
     template< typename T >
     static void cgi_getenv_int(const char*, T&);
-
     static void cgi_getenv_bool(const char*, bool&);
 
     CgiRequest::CgiRequest()
@@ -50,6 +49,18 @@ namespace tempearly
     String CgiRequest::GetPath() const
     {
         return m_path;
+    }
+
+    bool CgiRequest::IsSecure() const
+    {
+        char* value = std::getenv("HTTPS");
+
+        if (value && *value)
+        {
+            return !std::strcmp(value, "on");
+        } else {
+            return false;
+        }
     }
 
     bool CgiRequest::IsAjax() const
@@ -106,7 +117,7 @@ namespace tempearly
         cgi_getenv_str("PATH_INFO", m_path_info);
         cgi_getenv_str("PATH_TRANSLATED", m_path_translated);
         cgi_getenv_str("SCRIPT_NAME", m_script_name);
-        cgi_getenv_str("QUERY_STRING", m_query_string);
+        cgi_getenv_bin("QUERY_STRING", m_query_string);
         cgi_getenv_str("REMOTE_HOST", m_remote_host);
         cgi_getenv_str("REMOTE_ADDR", m_remote_addr);
         cgi_getenv_str("AUTH_TYPE", m_auth_type);
@@ -152,6 +163,20 @@ namespace tempearly
             }
             delete[] buffer;
         }
+    }
+
+    static bool cgi_getenv_bin(const char* name, ByteString& slot)
+    {
+        char* value = std::getenv(name);
+
+        if (value && *value)
+        {
+            slot = value;
+
+            return true;
+        }
+
+        return false;
     }
 
     static bool cgi_getenv_str(const char* name, String& slot)

--- a/src/sapi/cgi/request.h
+++ b/src/sapi/cgi/request.h
@@ -1,6 +1,7 @@
 #ifndef TEMPEARLY_SAPI_CGI_REQUEST_H_GUARD
 #define TEMPEARLY_SAPI_CGI_REQUEST_H_GUARD
 
+#include "core/bytestring.h"
 #include "sapi/request.h"
 
 namespace tempearly
@@ -13,6 +14,8 @@ namespace tempearly
         HttpMethod::Kind GetMethod() const;
 
         String GetPath() const;
+
+        bool IsSecure() const;
 
         bool IsAjax() const;
 
@@ -39,7 +42,7 @@ namespace tempearly
         String m_path_info;
         String m_path_translated;
         String m_script_name;
-        String m_query_string;
+        ByteString m_query_string;
         String m_remote_host;
         String m_remote_addr;
         String m_auth_type;

--- a/src/sapi/httpd/request.cc
+++ b/src/sapi/httpd/request.cc
@@ -8,7 +8,7 @@ namespace tempearly
     HttpServerRequest::HttpServerRequest(const Handle<Socket>& socket,
                                          HttpMethod::Kind method,
                                          const String& path,
-                                         const String& query_string,
+                                         const ByteString& query_string,
                                          const Dictionary<String>& headers,
                                          const byte* data,
                                          std::size_t data_size)
@@ -25,7 +25,7 @@ namespace tempearly
             && GetContentType() == "application/x-www-form-urlencoded"
             && GetContentLength() > 0)
         {
-            Utils::ParseQueryString(ByteString(data, data_size).c_str(), m_parameters);
+            Utils::ParseQueryString(data, data_size, m_parameters);
         }
     }
 
@@ -37,6 +37,11 @@ namespace tempearly
     String HttpServerRequest::GetPath() const
     {
         return m_path;
+    }
+
+    bool HttpServerRequest::IsSecure() const
+    {
+        return false;
     }
 
     bool HttpServerRequest::IsAjax() const

--- a/src/sapi/httpd/request.h
+++ b/src/sapi/httpd/request.h
@@ -14,7 +14,7 @@ namespace tempearly
         explicit HttpServerRequest(const Handle<Socket>& socket,
                                    HttpMethod::Kind method,
                                    const String& path,
-                                   const String& query_string,
+                                   const ByteString& query_string,
                                    const Dictionary<String>& headers,
                                    const byte* data,
                                    std::size_t data_size);
@@ -22,6 +22,8 @@ namespace tempearly
         HttpMethod::Kind GetMethod() const;
 
         String GetPath() const;
+
+        bool IsSecure() const;
 
         bool IsAjax() const;
 

--- a/src/sapi/httpd/server.h
+++ b/src/sapi/httpd/server.h
@@ -20,7 +20,7 @@ namespace tempearly
         {
             HttpMethod::Kind method;
             String path;
-            String query_string;
+            ByteString query_string;
             HttpVersion::Kind version;
             Dictionary<String> headers;
         };

--- a/src/sapi/request.h
+++ b/src/sapi/request.h
@@ -28,6 +28,12 @@ namespace tempearly
         virtual String GetPath() const = 0;
 
         /**
+         * Attempts to find out whether the request was made through a secure
+         * channel such as HTTPS.
+         */
+        virtual bool IsSecure() const = 0;
+
+        /**
          * Attempts to find out whether the request was made with
          * XMLHttpRequest or not.
          */

--- a/src/utils.h
+++ b/src/utils.h
@@ -38,11 +38,16 @@ namespace tempearly
         static String ToString(double number);
 
         /**
-         * Parses given given string as query string and inserts named values
+         * Parses given byte string as query string and inserts named values
          * extracted from it to the given dictionary.
          */
-        static void ParseQueryString(const String& string,
-                                     Dictionary<Vector<String> >& dictionary);
+        static void ParseQueryString(const ByteString& input, Dictionary<Vector<String> >& dictionary);
+
+        /**
+         * Parses given byte array as query string and inserts named values
+         * extracted from it to the given dictionary.
+         */
+        static void ParseQueryString(const byte* input, std::size_t length, Dictionary<Vector<String> >& dictionary);
 
     private:
         TEMPEARLY_DISALLOW_IMPLICIT_CONSTRUCTORS(Utils);


### PR DESCRIPTION
In order the increase performance and to decrease memory usage, this
commit modifies various parts of the SAPI, URL decoding and query string
parsing to use byte strings instead of Unicode strings. Decision to use
Unicode strings instead of byte strings for these functions was stupid
in the first place, because those strings need to be constantly encoded
and decoded which costs memory and CPU time.

Also added new SAPI/API method `IsSecure` to `Request` class which
attempts to find out whether the request was made through HTTPS or not.

As an intresting side note, when this is compiled with GCC 4.9.1 with
`-O3 -pipe` flags set, the builtin HTTPD crashes after first request
with error message "stack smashing detected". According to Google, this
error message is caused by an buffer overflow, but Valgrind is unable to
detect any and if compiled without those optimization flags HTTPD runs
happily without crashes. Most likely this happens because GCC has just
become so shitty and it's nowdays notorious for it's bugs. Use Clang
everywhere.
