### PR TITLE
Throw statement.

### DIFF
--- a/src/api/class.cc
+++ b/src/api/class.cc
@@ -146,7 +146,7 @@ namespace tempearly
                         StringBuilder sb;
 
                         sb << "Method expected at least "
-                           << (-(m_arity) - 1)
+                           << Utils::ToString(static_cast<u64>(-(m_arity) - 1))
                            << " arguments, got "
                            << Utils::ToString(static_cast<u64>(args.GetSize()));
                         interpreter->Throw(interpreter->eTypeError, sb.ToString());
@@ -159,7 +159,7 @@ namespace tempearly
                     StringBuilder sb;
 
                     sb << "Method expected "
-                       << m_arity
+                       << Utils::ToString(static_cast<u64>(m_arity))
                        << " arguments, got "
                        << Utils::ToString(static_cast<u64>(args.GetSize()));
                     interpreter->Throw(interpreter->eTypeError, sb.ToString());
@@ -228,7 +228,7 @@ namespace tempearly
                         StringBuilder sb;
 
                         sb << "Method expected at least "
-                           << (-(m_arity) - 1)
+                           << Utils::ToString(static_cast<u64>(-(m_arity) - 1))
                            << " arguments, got "
                            << Utils::ToString(static_cast<u64>(args.GetSize()));
                         interpreter->Throw(interpreter->eTypeError, sb.ToString());
@@ -241,7 +241,7 @@ namespace tempearly
                     StringBuilder sb;
 
                     sb << "Method expected "
-                       << m_arity
+                       << Utils::ToString(static_cast<u64>(m_arity))
                        << " arguments, got "
                        << Utils::ToString(static_cast<u64>(args.GetSize()));
                     interpreter->Throw(interpreter->eTypeError, sb.ToString());

--- a/src/api/exception.cc
+++ b/src/api/exception.cc
@@ -17,6 +17,41 @@ namespace tempearly
         }
     }
 
+    /**
+     * Exception#__init__(message = null)
+     *
+     * Constructs exception with given error message.
+     *
+     * Throws: TypeError - If anything else than String or null is given as
+     * argument.
+     */
+    TEMPEARLY_NATIVE_METHOD(ex_init)
+    {
+        if (args.GetSize() == 2)
+        {
+            const Value& message = args[1];
+
+            if (message.Is(Value::KIND_STRING))
+            {
+                args[0].SetAttribute("message", args[1]);
+            }
+            else if (!message.Is(Value::KIND_NULL))
+            {
+                interpreter->Throw(interpreter->eTypeError, "String required");
+
+                return Value();
+            }
+        }
+        else if (args.GetSize() > 2)
+        {
+            interpreter->Throw(interpreter->eValueError, "Too many arguments");
+
+            return Value();
+        }
+
+        return Value::NullValue();
+    }
+
     static Handle<CoreObject> ex_alloc(const Handle<Interpreter>& interpreter,
                                        const Handle<Class>& cls)
     {
@@ -28,6 +63,7 @@ namespace tempearly
         i->cException = i->AddClass("Exception", i->cObject);
 
         i->cException->SetAllocator(ex_alloc);
+        i->cException->AddMethod(i, "__init__", -1, ex_init);
 
         i->eAttributeError = i->AddClass("AttributeError", i->cException);
         i->eIOError = i->AddClass("IOError", i->cException);

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -36,6 +36,7 @@ namespace tempearly
         , response(0)
         , globals(0)
         , m_exception(0)
+        , m_caught_exception(0)
         , m_scope(0)
         , m_empty_iterator(0)
         , m_imported_files(0) {}
@@ -320,6 +321,10 @@ namespace tempearly
         if (m_exception && !m_exception->IsMarked())
         {
             m_exception->Mark();
+        }
+        if (m_caught_exception && !m_caught_exception->IsMarked())
+        {
+            m_caught_exception->Mark();
         }
         if (m_scope && !m_scope->IsMarked())
         {

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -47,11 +47,44 @@ namespace tempearly
         }
 
         /**
-         * Clears current exception if such exists.
+         * Sets currently uncaught exception.
+         */
+        inline void SetException(const Handle<ExceptionObject>& exception)
+        {
+            m_exception = exception.Get();
+        }
+
+        /**
+         * Clears current uncaught exception if such exists.
          */
         inline void ClearException()
         {
             m_exception = 0;
+        }
+
+        /**
+         * Returns currently caught exception or NULL handle if there isn't
+         * any.
+         */
+        inline Handle<ExceptionObject> GetCaughtException() const
+        {
+            return m_caught_exception;
+        }
+
+        /**
+         * Sets currently caught exception.
+         */
+        inline void SetCaughtException(const Handle<ExceptionObject>& caught_exception)
+        {
+            m_caught_exception = caught_exception.Get();
+        }
+
+        /**
+         * Clears current caught exception if such exists.
+         */
+        inline void ClearCaughtException()
+        {
+            m_caught_exception = 0;
         }
 
         /**
@@ -136,6 +169,8 @@ namespace tempearly
     private:
         /** Current uncaught exception. */
         ExceptionObject* m_exception;
+        /** Current caught exception. */
+        ExceptionObject* m_caught_exception;
         /** Current local variable scope. */
         Scope* m_scope;
         /** Shared instance of empty iterator. */

--- a/src/node.h
+++ b/src/node.h
@@ -216,6 +216,20 @@ namespace tempearly
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(ReturnNode);
     };
 
+    class ThrowNode : public Node
+    {
+    public:
+        explicit ThrowNode(const Handle<Node>& exception = Handle<Node>());
+
+        Result Execute(const Handle<Interpreter>& interpreter) const;
+
+        void Mark();
+
+    private:
+        Node* m_exception;
+        TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(ThrowNode);
+    };
+
     class ValueNode : public Node
     {
     public:

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1207,7 +1207,21 @@ SCAN_EXPONENT:
                 break;
             }
 
-            //TODO:case Token::KW_THROW:
+            case Token::KW_THROW:
+            {
+                Handle<Node> exception;
+
+                parser->SkipToken();
+                if (!parser->PeekToken(Token::SEMICOLON))
+                {
+                    if (!(exception = parse_expr(parser)))
+                    {
+                        return Handle<Node>();
+                    }
+                }
+                node = new ThrowNode(exception);
+                break;
+            }
 
             default:
                 node = parse_expr(parser);
@@ -1391,9 +1405,18 @@ SCAN_EXPONENT:
         }
         if (parser->ReadToken(Token::ARROW))
         {
-            Handle<Node> node = parse_expr(parser);
+            Handle<Node> node;
 
-            if (!node)
+            if (parser->ReadToken(Token::KW_THROW))
+            {
+                if (!(node = parse_expr(parser)))
+                {
+                    return Handle<Node>();
+                }
+
+                return new ThrowNode(node);
+            }
+            else if (!(node = parse_expr(parser)))
             {
                 return Handle<Node>();
             }


### PR DESCRIPTION
1. Add support for `throw` statement which can be used to throw
   exceptions. Not very useful until we have a `try` exception which can
   catch them.
   
   `throw` statement can be used to throw new exceptions or previouly
   caught exceptions. Only objects which are instance of `Exception`
   class can be thrown, otherwise an `TypeError` is thrown.
2. Add support for `Interpreter` class to track caught exceptions,
   alongside with uncaught exceptions. Required for `throw` statement.
3. Fix minor yet annoying bugs where the number of required arguments
   was not properly converted to string in error messages.
