### PR TITLE
Add support for try statement.

### DIFF
--- a/src/api/bool.cc
+++ b/src/api/bool.cc
@@ -1,4 +1,5 @@
 #include "interpreter.h"
+#include "api/class.h"
 #include "core/random.h"
 
 namespace tempearly

--- a/src/api/exception.cc
+++ b/src/api/exception.cc
@@ -1,4 +1,5 @@
 #include "interpreter.h"
+#include "api/exception.h"
 
 namespace tempearly
 {

--- a/src/api/filters.cc
+++ b/src/api/filters.cc
@@ -1,4 +1,5 @@
 #include "interpreter.h"
+#include "api/class.h"
 
 namespace tempearly
 {

--- a/src/api/iterator.cc
+++ b/src/api/iterator.cc
@@ -171,7 +171,7 @@ namespace tempearly
         {
             return Value::NewBool(true);
         }
-        else if (interpreter->GetException()->IsInstance(interpreter, interpreter->eStopIteration))
+        else if (interpreter->GetException().IsInstance(interpreter, interpreter->eStopIteration))
         {
             interpreter->ClearException();
 

--- a/src/api/number.cc
+++ b/src/api/number.cc
@@ -2,6 +2,7 @@
 
 #include "interpreter.h"
 #include "utils.h"
+#include "api/class.h"
 #include "core/random.h"
 
 namespace tempearly

--- a/src/api/object.cc
+++ b/src/api/object.cc
@@ -1,4 +1,6 @@
 #include "interpreter.h"
+#include "api/class.h"
+#include "api/object.h"
 #include "core/stringbuilder.h"
 
 namespace tempearly

--- a/src/api/request.cc
+++ b/src/api/request.cc
@@ -1,4 +1,5 @@
 #include "interpreter.h"
+#include "api/object.h"
 
 namespace tempearly
 {

--- a/src/api/response.cc
+++ b/src/api/response.cc
@@ -1,4 +1,5 @@
 #include "interpreter.h"
+#include "api/object.h"
 
 namespace tempearly
 {

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -1,6 +1,7 @@
 #include "interpreter.h"
 #include "parser.h"
 #include "utils.h"
+#include "api/exception.h"
 #include "api/function.h"
 #include "api/iterator.h"
 #include "api/map.h"
@@ -35,8 +36,6 @@ namespace tempearly
         : request(0)
         , response(0)
         , globals(0)
-        , m_exception(0)
-        , m_caught_exception(0)
         , m_scope(0)
         , m_empty_iterator(0)
         , m_imported_files(0) {}
@@ -253,7 +252,7 @@ namespace tempearly
             Handle<ExceptionObject> exception = new ExceptionObject(cls);
 
             exception->SetAttribute("message", Value::NewString(message));
-            m_exception = exception.Get();
+            m_exception = Value(exception);
         } else {
             std::fprintf(stderr,
                          "%s (fatal internal error)\n",
@@ -318,14 +317,8 @@ namespace tempearly
         {
             globals->Mark();
         }
-        if (m_exception && !m_exception->IsMarked())
-        {
-            m_exception->Mark();
-        }
-        if (m_caught_exception && !m_caught_exception->IsMarked())
-        {
-            m_caught_exception->Mark();
-        }
+        m_exception.Mark();
+        m_caught_exception.Mark();
         if (m_scope && !m_scope->IsMarked())
         {
             m_scope->Mark();

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -2,7 +2,6 @@
 #define TEMPEARLY_INTERPRETER_H_GUARD
 
 #include "scope.h"
-#include "api/exception.h"
 #include "sapi/request.h"
 #include "sapi/response.h"
 
@@ -41,7 +40,7 @@ namespace tempearly
          * Returns currently uncaught exception or NULL handle if there isn't
          * any.
          */
-        inline Handle<ExceptionObject> GetException() const
+        inline const Value& GetException() const
         {
             return m_exception;
         }
@@ -49,9 +48,9 @@ namespace tempearly
         /**
          * Sets currently uncaught exception.
          */
-        inline void SetException(const Handle<ExceptionObject>& exception)
+        inline void SetException(const Value& exception)
         {
-            m_exception = exception.Get();
+            m_exception = exception;
         }
 
         /**
@@ -59,14 +58,14 @@ namespace tempearly
          */
         inline void ClearException()
         {
-            m_exception = 0;
+            m_exception.Clear();
         }
 
         /**
          * Returns currently caught exception or NULL handle if there isn't
          * any.
          */
-        inline Handle<ExceptionObject> GetCaughtException() const
+        inline const Value& GetCaughtException() const
         {
             return m_caught_exception;
         }
@@ -74,9 +73,9 @@ namespace tempearly
         /**
          * Sets currently caught exception.
          */
-        inline void SetCaughtException(const Handle<ExceptionObject>& caught_exception)
+        inline void SetCaughtException(const Value& caught_exception)
         {
-            m_caught_exception = caught_exception.Get();
+            m_caught_exception = caught_exception;
         }
 
         /**
@@ -84,7 +83,7 @@ namespace tempearly
          */
         inline void ClearCaughtException()
         {
-            m_caught_exception = 0;
+            m_caught_exception.Clear();
         }
 
         /**
@@ -168,9 +167,9 @@ namespace tempearly
 
     private:
         /** Current uncaught exception. */
-        ExceptionObject* m_exception;
+        Value m_exception;
         /** Current caught exception. */
-        ExceptionObject* m_caught_exception;
+        Value m_caught_exception;
         /** Current local variable scope. */
         Scope* m_scope;
         /** Shared instance of empty iterator. */

--- a/src/node.h
+++ b/src/node.h
@@ -180,6 +180,44 @@ namespace tempearly
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(ForNode);
     };
 
+    class CatchNode : public Node
+    {
+    public:
+        explicit CatchNode(const Handle<TypeHint>& type, const Handle<Node>& variable, const Handle<Node>& statement);
+
+        bool IsCatch(const Handle<Interpreter>& interpreter, const Value& exception, bool& slot) const;
+
+        Result Execute(const Handle<Interpreter>& interpreter) const;
+
+        void Mark();
+
+    private:
+        TypeHint* m_type;
+        Node* m_variable;
+        Node* m_statement;
+        TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(CatchNode);
+    };
+
+    class TryNode : public Node
+    {
+    public:
+        explicit TryNode(const Handle<Node>& statement,
+                         const Vector<Handle<CatchNode> >& catches = Vector<Handle<CatchNode> >(),
+                         const Handle<Node>& else_statement = Handle<Node>(),
+                         const Handle<Node>& finally_statement = Handle<Node>());
+
+        Result Execute(const Handle<Interpreter>& interpreter) const;
+
+        void Mark();
+
+    private:
+        Node* m_statement;
+        const Vector<CatchNode*> m_catches;
+        Node* m_else_statement;
+        Node* m_finally_statement;
+        TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(TryNode);
+    };
+
     class BreakNode : public Node
     {
     public:

--- a/src/sapi/response.cc
+++ b/src/sapi/response.cc
@@ -1,3 +1,4 @@
+#include "value.h"
 #include "api/exception.h"
 #include "core/bytestring.h"
 #include "sapi/response.h"
@@ -55,20 +56,21 @@ namespace tempearly
         Write(bytes.GetLength(), bytes.c_str());
     }
 
-    void Response::SendException(const Handle<ExceptionObject>& exception)
+    void Response::SendException(const Value& exception)
     {
-        if (!exception)
+        if (exception.IsException())
         {
-            return; // Just in case
-        }
-        else if (IsCommitted())
-        {
-            Write("\n<p><strong>ERROR:</strong> " + exception->GetMessage().EscapeXml() + "</p>\n");
-        } else {
-            m_headers.Clear();
-            SetHeader("Content-Type", "text/plain; charset=utf-8");
-            m_status = 500;
-            Write("ERROR:\n" + exception->GetMessage() + "\n");
+            String message = exception.As<ExceptionObject>()->GetMessage();
+
+            if (IsCommitted())
+            {
+                Write("\n<p><strong>ERROR:</strong> " + message.EscapeXml() + "</p>\n");
+            } else {
+                m_headers.Clear();
+                SetHeader("Content-Type", "text/plain; charset=utf-8");
+                m_status = 500;
+                Write("ERROR:\n" + message + "\n");
+            }
         }
     }
 }

--- a/src/sapi/response.h
+++ b/src/sapi/response.h
@@ -80,7 +80,7 @@ namespace tempearly
 
         virtual void Write(std::size_t size, const char* data) = 0;
 
-        void SendException(const Handle<ExceptionObject>& exception);
+        void SendException(const Value& exception);
 
     private:
         /** Status code of the response. */

--- a/src/scope.cc
+++ b/src/scope.cc
@@ -1,4 +1,5 @@
 #include "interpreter.h"
+#include "api/object.h"
 
 namespace tempearly
 {

--- a/src/token.cc
+++ b/src/token.cc
@@ -63,20 +63,23 @@ namespace tempearly
             case NOT: return "`!'";
             case BIT_NOT: return "`~'";
 
-            case KW_BREAK: return "`break'";
-            case KW_CONTINUE: return "`continue'";
-            case KW_DO: return "`do'";
-            case KW_ELSE: return "`else'";
-            case KW_END: return "`end'";
-            case KW_FALSE: return "`false'";
-            case KW_FOR: return "`for'";
-            case KW_FUNCTION: return "`function'";
-            case KW_IF: return "`if'";
-            case KW_NULL: return "`null'";
-            case KW_RETURN: return "`return'";
-            case KW_THROW: return "`throw'";
-            case KW_TRUE: return "`true'";
-            case KW_WHILE: return "`while'";
+            case KW_BREAK: return "'break'";
+            case KW_CATCH: return "'catch'";
+            case KW_CONTINUE: return "'continue'";
+            case KW_DO: return "'do'";
+            case KW_ELSE: return "'else'";
+            case KW_END: return "'end'";
+            case KW_FALSE: return "'false'";
+            case KW_FINALLY: return "'finally'";
+            case KW_FOR: return "'for'";
+            case KW_FUNCTION: return "'function'";
+            case KW_IF: return "'if'";
+            case KW_NULL: return "'null'";
+            case KW_RETURN: return "'return'";
+            case KW_THROW: return "'throw'";
+            case KW_TRUE: return "'true'";
+            case KW_TRY: return "'try'";
+            case KW_WHILE: return "'while'";
             
             case IDENTIFIER: return "identifier";
             case STRING: return "string literal";

--- a/src/token.h
+++ b/src/token.h
@@ -74,11 +74,13 @@ namespace tempearly
 
             // Keywords
             KW_BREAK,
+            KW_CATCH,
             KW_CONTINUE,
             KW_DO,
             KW_ELSE,
             KW_END,
             KW_FALSE,
+            KW_FINALLY,
             KW_FOR,
             KW_FUNCTION,
             KW_IF,
@@ -86,6 +88,7 @@ namespace tempearly
             KW_RETURN,
             KW_THROW,
             KW_TRUE,
+            KW_TRY,
             KW_WHILE,
             
             IDENTIFIER,

--- a/src/value.cc
+++ b/src/value.cc
@@ -390,9 +390,9 @@ namespace tempearly
 
         if (interpreter->HasException())
         {
-            Handle<ExceptionObject> exception = interpreter->GetException();
+            const Value& exception = interpreter->GetException();
 
-            if (exception->IsInstance(interpreter, interpreter->eStopIteration))
+            if (exception.IsInstance(interpreter, interpreter->eStopIteration))
             {
                 interpreter->ClearException();
             }


### PR DESCRIPTION
1. Modifies `Interpreter` class so that caught and uncaught exceptions
   are stored as `Value` instances, instead of `ExceptionObject`. This
   gives us more flexibility with AST.
2. Adds support for `try` statement which can be used to catch
   exceptions thrown either by API methods or `throw` statement.
   
   `try` statement has following kind of syntax:
   
   ```
   try:
      throw Exception("this is exception message");
   catch Exception ex:
      response.write("Exception caught: " + ex.message);
   else:
      response.write("No exception was thrown.");
   finally:
      response.write("This is always executed.")
   end try;
   ```
   
   There can be more than one `catch` statement to catch various kinds
   of exceptions. `catch` statements can also be completely omitted if
   an `else` or `finally` statement is provided.
   
   `catch` statements take an optional type and variable. Type is an
   type hint (the kind that is used in function parameters), thus it
   allows you to catch multiple kinds of exceptions with syntax like
   `IOError|TypeError|LookupError`. Type can also be omitted, in which
   case every kind of exception is caught. Variable can also be omitted.
   
   `try` statement can also have an `else` substatement, which is
   executed only if no exception was thrown in body of the `try`
   statement. This is ripped off from Python and is very handy
   sometimes.
   
   If `try` statement has an `finally` substatement, then that statement
   is always executed, no matter what happens. It is also kinda
   dangerous thing to have, if `finally` statement throws an exception
   things can go completely bonk with the interpreter, althought it
   doesn't crash or anything.
