### PR TITLE
Unify request parameter handling.

### DIFF
--- a/examples/form.tly
+++ b/examples/form.tly
@@ -9,11 +9,11 @@
 <body>
     <div class="container">
         <h1>Form test</h1>
-        {% if request.method() == "POST": %}
-            <p>Welcome {{request["name"]}}</p>
-            <p>Your e-mail address is: {{request["email"]}}</p>
+        {% if request.is_post(): %}
+            <p>Welcome {{ request["name"] }}</p>
+            <p>Your e-mail address is: {{ request["email"] }}</p>
         {% else: %}
-            <form class="form-horizontal" method="post" action="{{request.path()}}" role="form">
+            <form class="form-horizontal" method="post" action="{{ request.path() }}" role="form">
                 <div class="form-group">
                     <label for="name">Name:</label>
                     <input type="text" class="form-control" name="name" id="name" autofocus required>

--- a/src/api/string.cc
+++ b/src/api/string.cc
@@ -17,19 +17,26 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(str_s_call)
     {
-        StringBuilder result;
-        String slot;
+        const std::size_t size = args.GetSize();
 
-        for (std::size_t i = 0; i < args.GetSize(); ++i)
+        if (size == 1 && args[0].IsString())
         {
-            if (!args[i].ToString(interpreter, slot))
-            {
-                return Value();
-            }
-            result << slot;
-        }
+            return args[0];
+        } else {
+            StringBuilder result;
+            String slot;
 
-        return Value::NewString(result.ToString());
+            for (std::size_t i = 0; i < size; ++i)
+            {
+                if (!args[i].ToString(interpreter, slot))
+                {
+                    return Value();
+                }
+                result << slot;
+            }
+
+            return Value::NewString(result.ToString());
+        }
     }
 
     /**

--- a/src/sapi/apache/request.h
+++ b/src/sapi/apache/request.h
@@ -3,7 +3,6 @@
 
 #include <httpd.h>
 
-#include "core/dictionary.h"
 #include "sapi/request.h"
 
 namespace tempearly
@@ -13,6 +12,8 @@ namespace tempearly
     public:
         explicit ApacheRequest(request_rec* request);
 
+        ~ApacheRequest();
+
         HttpMethod::Kind GetMethod() const;
 
         String GetPath() const;
@@ -21,18 +22,18 @@ namespace tempearly
 
         bool IsAjax() const;
 
-        bool HasParameter(const String& id) const;
+        String GetContentType() const;
 
-        bool GetParameter(const String& id, String& value) const;
+        std::size_t GetContentLength() const;
 
-    private:
-        void ReadParameters();
+        ByteString GetBody();
+
+        ByteString GetQueryString();
 
     private:
         request_rec* m_request;
         const HttpMethod::Kind m_method;
-        Dictionary<Vector<String> > m_parameters;
-        bool m_parameters_read;
+        ByteString* m_body;
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(ApacheRequest);
     };
 }

--- a/src/sapi/cgi/request.h
+++ b/src/sapi/cgi/request.h
@@ -11,6 +11,8 @@ namespace tempearly
     public:
         explicit CgiRequest();
 
+        ~CgiRequest();
+
         HttpMethod::Kind GetMethod() const;
 
         String GetPath() const;
@@ -19,17 +21,19 @@ namespace tempearly
 
         bool IsAjax() const;
 
-        bool HasParameter(const String& id) const;
+        String GetContentType() const;
 
-        bool GetParameter(const String& id, String& value) const;
+        std::size_t GetContentLength() const;
+
+        ByteString GetBody();
+
+        ByteString GetQueryString();
 
     private:
         void ReadEnvironmentVariables();
-        void ReadParameters();
+        void ReadBody();
 
     private:
-        Dictionary<Vector<String> > m_parameters;
-        bool m_parameters_read;
         /** Request method ("GET", "POST", etc.). */
         String m_method;
         /** Requested URI. */
@@ -58,6 +62,7 @@ namespace tempearly
         String m_referrer;
         String m_cookie;
         bool m_using_https;
+        ByteString* m_body;
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(CgiRequest);
     };
 }

--- a/src/sapi/httpd/request.h
+++ b/src/sapi/httpd/request.h
@@ -1,7 +1,6 @@
 #ifndef TEMPEARLY_SAPI_HTTPD_REQUEST_H_GUARD
 #define TEMPEARLY_SAPI_HTTPD_REQUEST_H_GUARD
 
-#include "core/dictionary.h"
 #include "sapi/request.h"
 
 namespace tempearly
@@ -16,8 +15,10 @@ namespace tempearly
                                    const String& path,
                                    const ByteString& query_string,
                                    const Dictionary<String>& headers,
-                                   const byte* data,
-                                   std::size_t data_size);
+                                   const byte* body,
+                                   std::size_t body_size);
+
+        ~HttpServerRequest();
 
         HttpMethod::Kind GetMethod() const;
 
@@ -27,17 +28,17 @@ namespace tempearly
 
         bool IsAjax() const;
 
-        bool HasParameter(const String& id) const;
+        String GetContentType() const;
 
-        bool GetParameter(const String& id, String& slot) const;
+        std::size_t GetContentLength() const;
+
+        ByteString GetBody();
+
+        ByteString GetQueryString();
 
         bool HasHeader(const String& id) const;
 
         bool GetHeader(const String& id, String& slot) const;
-
-        String GetContentType() const;
-
-        std::size_t GetContentLength() const;
 
         void Mark();
 
@@ -45,8 +46,9 @@ namespace tempearly
         Socket* m_socket;
         const HttpMethod::Kind m_method;
         const String m_path;
-        Dictionary<String> m_headers;
-        Dictionary<Vector<String> > m_parameters;
+        const ByteString m_query_string;
+        const Dictionary<String> m_headers;
+        ByteString* m_body;
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(HttpServerRequest);
     };
 }

--- a/src/sapi/request.cc
+++ b/src/sapi/request.cc
@@ -1,8 +1,105 @@
+#include "utils.h"
+#include "core/bytestring.h"
 #include "sapi/request.h"
 
 namespace tempearly
 {
-    Request::Request() {}
+    Request::Request()
+        : m_parameters_parsed(false) {}
 
     Request::~Request() {}
+
+    Vector<String> Request::GetParameterNames()
+    {
+        Vector<String> names;
+
+        if (!m_parameters_parsed)
+        {
+            ParseParameters();
+        }
+        for (const ParameterMap::Entry* entry = m_parameters.GetFront(); entry; entry = entry->GetNext())
+        {
+            names.PushBack(entry->GetName());
+        }
+
+        return names;
+    }
+
+    bool Request::HasParameter(const String& id)
+    {
+        const ParameterMap::Entry* entry;
+
+        if (!m_parameters_parsed)
+        {
+            ParseParameters();
+        }
+        
+        return (entry = m_parameters.Find(id)) && !entry->GetValue().IsEmpty();
+    }
+
+    bool Request::GetParameter(const String& id, String& value)
+    {
+        const ParameterMap::Entry* entry;
+
+        if (!m_parameters_parsed)
+        {
+            ParseParameters();
+        }
+        if ((entry = m_parameters.Find(id)))
+        {
+            const Vector<String>& values = entry->GetValue();
+
+            if (!values.IsEmpty())
+            {
+                value = values.GetFront();
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    bool Request::GetAllParameters(const String& id, Vector<String>& values)
+    {
+        const ParameterMap::Entry* entry;
+
+        if (!m_parameters_parsed)
+        {
+            ParseParameters();
+        }
+        if ((entry = m_parameters.Find(id)))
+        {
+            const Vector<String>& values2 = entry->GetValue();
+
+            if (!values2.IsEmpty())
+            {
+                values = values2;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    void Request::ParseParameters()
+    {
+        const ByteString query_string = GetQueryString();
+
+        m_parameters_parsed = true;
+        if (!query_string.IsEmpty())
+        {
+            Utils::ParseQueryString(query_string.GetBytes(), query_string.GetLength(), m_parameters);
+        }
+        // TODO: process multipart requests
+        if (GetMethod() == HttpMethod::POST
+            && GetContentLength() > 0
+            && GetContentType() == "application/x-www-form-urlencoded")
+        {
+            const ByteString body = GetBody();
+
+            Utils::ParseQueryString(body.GetBytes(), body.GetLength(), m_parameters);
+        }
+    }
 }

--- a/src/sapi/request.h
+++ b/src/sapi/request.h
@@ -1,7 +1,8 @@
 #ifndef TEMPERALY_SAPI_REQUEST_H_GUARD
 #define TEMPERALY_SAPI_REQUEST_H_GUARD
 
-#include "memory.h"
+#include "core/dictionary.h"
+#include "core/vector.h"
 #include "http/method.h"
 
 namespace tempearly
@@ -9,6 +10,8 @@ namespace tempearly
     class Request : public CountedObject
     {
     public:
+        typedef Dictionary<Vector<String> > ParameterMap;
+
         explicit Request();
 
         virtual ~Request();
@@ -39,11 +42,48 @@ namespace tempearly
          */
         virtual bool IsAjax() const = 0;
 
-        virtual bool HasParameter(const String& id) const = 0;
+        /**
+         * Returns value of the Content-Type header sent by the client or an
+         * empty string if the client did not send that specific header.
+         */
+        virtual String GetContentType() const = 0;
 
-        virtual bool GetParameter(const String& id, String& value) const = 0;
+        /**
+         * Returns value of the Content-Length header sent by the client or 0
+         * if the client did not send that specific header or it's value is
+         * indeed a zero.
+         */
+        virtual std::size_t GetContentLength() const = 0;
+
+        /**
+         * Returns body of the request as binary string or empty binary string
+         * if the client did not send anything with the request.
+         */
+        virtual ByteString GetBody() = 0;
+
+        /**
+         * Returns the query string extracted from the URL or empty byte string
+         * if the client did not send a request containing query string.
+         */
+        virtual ByteString GetQueryString() = 0;
+
+        /**
+         * Returns names of all request parameters included in this request.
+         */
+        Vector<String> GetParameterNames();
+
+        bool HasParameter(const String& id);
+
+        bool GetParameter(const String& id, String& value);
+
+        bool GetAllParameters(const String& id, Vector<String>& values);
 
     private:
+        void ParseParameters();
+
+    private:
+        ParameterMap m_parameters;
+        bool m_parameters_parsed;
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(Request);
     };
 }


### PR DESCRIPTION
Instead of each SAPI having it's own methods to parse request
parameters, `Request` class now has a single unified way to parse them.
This however requires that each subclass of `Request` has to provide
methods to retrieve query string and request body, but this is not bad
thing to have as they could be useful later.

Also provides some improvements in request API, including retrieval of
request body and simpler testing whether the request was POST or GET.
