### PR TITLE
Bug fix: Typeless builtin methods.

### DIFF
--- a/src/api/function.cc
+++ b/src/api/function.cc
@@ -161,7 +161,7 @@ namespace tempearly
 
     void init_function(Interpreter* i)
     {
-        i->cFunction = i->AddClass("Function", i->cObject);
+        Handle<Class> cFunction = i->cFunction;
 
         i->cFunction->SetAllocator(Class::kNoAlloc);
 

--- a/src/api/object.cc
+++ b/src/api/object.cc
@@ -305,8 +305,10 @@ namespace tempearly
     void init_object(Interpreter* i)
     {
         Handle<Class> cObject = i->AddClass("Object", Handle<Class>());
+        Handle<Class> cFunction = i->AddClass("Function", cObject);
 
         i->cObject = cObject.Get();
+        i->cFunction = cFunction.Get();
 
         cObject->AddMethod(i, "__init__", 0, obj_init);
         cObject->AddMethod(i, "__hash__", 0, obj_hash);


### PR DESCRIPTION
Fixes an issue where some builtin methods remain typeless because
`Interpreter::cFunction` is initialized after builtin methods have been
constructed.
