### PR TITLE
Changes in the C++ API.

### DIFF
--- a/src/api/bool.cc
+++ b/src/api/bool.cc
@@ -24,18 +24,18 @@ namespace tempearly
                 || input.EqualsIgnoreCase("yes")
                 || input.EqualsIgnoreCase("on"))
             {
-                return Value::NewBool(true);
+                frame->SetReturnValue(Value::NewBool(true));
+                return;
             }
             else if (input.EqualsIgnoreCase("false")
                     || input.EqualsIgnoreCase("no")
                     || input.EqualsIgnoreCase("off"))
             {
-                return Value::NewBool(false);
+                frame->SetReturnValue(Value::NewBool(false));
+                return;
             }
             interpreter->Throw(interpreter->eValueError, "Invalid boolean");
         }
-
-        return Value();
     }
 
     /**
@@ -46,7 +46,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(bool_s_rand)
     {
-        return Value::NewBool(Random::NextBool());
+        frame->SetReturnValue(Value::NewBool(Random::NextBool()));
     }
 
     /**
@@ -56,7 +56,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(bool_hash)
     {
-        return Value::NewInt(args[0].AsBool() ? 1231 : 1237);
+        frame->SetReturnValue(Value::NewInt(args[0].AsBool() ? 1231 : 1237));
     }
 
     /**
@@ -67,7 +67,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(bool_str)
     {
-        return Value::NewString(args[0].AsBool() ? "true" : "false");
+        frame->SetReturnValue(Value::NewString(args[0].AsBool() ? "true" : "false"));
     }
 
     /**
@@ -82,15 +82,14 @@ namespace tempearly
         {
             bool b;
 
-            if (args[1].ToBool(interpreter, b))
+            if (!args[1].ToBool(interpreter, b))
             {
-                return b ? args[0] : Value::NewBool(false);
-            } else {
-                return Value();
+                return;
             }
+            frame->SetReturnValue(b ? args[0] : Value::NewBool(false));
+        } else {
+            frame->SetReturnValue(Value::NewBool(false));
         }
-
-        return Value::NewBool(false);
     }
 
     /**
@@ -103,15 +102,13 @@ namespace tempearly
     {
         if (args[0].AsBool())
         {
-            return args[0];
+            frame->SetReturnValue(args[0]);
         } else {
             bool b;
 
             if (args[1].ToBool(interpreter, b))
             {
-                return Value::NewBool(b);
-            } else {
-                return Value();
+                frame->SetReturnValue(Value::NewBool(b));
             }
         }
     }
@@ -130,12 +127,10 @@ namespace tempearly
         {
             if (b)
             {
-                return Value::NewBool(!args[0].AsBool());
+                frame->SetReturnValue(Value::NewBool(!args[0].AsBool()));
             } else {
-                return args[0];
+                frame->SetReturnValue(args[0]);
             }
-        } else {
-            return Value();
         }
     }
 

--- a/src/api/class.h
+++ b/src/api/class.h
@@ -9,9 +9,8 @@ namespace tempearly
     class Class : public CoreObject
     {
     public:
-        typedef Handle<CoreObject> (*Allocator)(const Handle<Interpreter>&,
-                                                const Handle<Class>&);
-        typedef Value (*MethodCallback)(const Handle<Interpreter>&, const Vector<Value>&);
+        typedef Handle<CoreObject> (*Allocator)(const Handle<Interpreter>&, const Handle<Class>&);
+        typedef void (*MethodCallback)(const Handle<Interpreter>&, const Handle<Frame>&, const Vector<Value>&);
 
         /**
          * Allocator which allocates nothing.

--- a/src/api/core.cc
+++ b/src/api/core.cc
@@ -37,9 +37,7 @@ namespace tempearly
 
         if (value_to_file(interpreter, args[0], file) && interpreter->Include(file))
         {
-            return Value::NewBool(true);
-        } else {
-            return Value();
+            frame->SetReturnValue(Value::NewBool(true));
         }
     }
 
@@ -62,9 +60,7 @@ namespace tempearly
 
         if (value_to_file(interpreter, args[0], file))
         {
-            return interpreter->Import(file);
-        } else {
-            return Value();
+            frame->SetReturnValue(interpreter->Import(file));
         }
     }
 

--- a/src/api/exception.cc
+++ b/src/api/exception.cc
@@ -49,18 +49,12 @@ namespace tempearly
             else if (!message.Is(Value::KIND_NULL))
             {
                 interpreter->Throw(interpreter->eTypeError, "String required");
-
-                return Value();
             }
         }
         else if (args.GetSize() > 2)
         {
             interpreter->Throw(interpreter->eValueError, "Too many arguments");
-
-            return Value();
         }
-
-        return Value::NullValue();
     }
 
     static Handle<CoreObject> ex_alloc(const Handle<Interpreter>& interpreter,

--- a/src/api/filters.cc
+++ b/src/api/filters.cc
@@ -16,9 +16,7 @@ namespace tempearly
 
         if (args[0].ToString(interpreter, string))
         {
-            return Value::NewString(string.EscapeJavaScript());
-        } else {
-            return Value();
+            frame->SetReturnValue(Value::NewString(string.EscapeJavaScript()));
         }
     }
 
@@ -34,9 +32,7 @@ namespace tempearly
 
         if (args[0].ToString(interpreter, string))
         {
-            return Value::NewString(string.EscapeXml());
-        } else {
-            return Value();
+            frame->SetReturnValue(Value::NewString(string.EscapeXml()));
         }
     }
 

--- a/src/api/function.h
+++ b/src/api/function.h
@@ -11,7 +11,7 @@ namespace tempearly
     class FunctionObject : public Object
     {
     public:
-        typedef Value(*Callback)(const Handle<Interpreter>&, const Vector<Value>&);
+        typedef void (*Callback)(const Handle<Interpreter>&, const Handle<Frame>&, const Vector<Value>&);
 
         /**
          * Default constructor.
@@ -39,11 +39,15 @@ namespace tempearly
          *
          * \param interpreter Script interpreter
          * \param args        Arguments given for the function
-         * \return            Value returned by the function, or error value if
+         * \param slot        Where result of the function execution will be
+         *                    assigned to
+         * \return            A boolean flag indicating whether execution of
+         *                    the function was successfull or not, or whether
          *                    an exception was thrown
          */
-        virtual Value Invoke(const Handle<Interpreter>& interpreter,
-                             const Vector<Value>& args) = 0;
+        virtual bool Invoke(const Handle<Interpreter>& interpreter,
+                            const Vector<Value>& args,
+                            Value& slot) = 0;
 
         /**
          * Creates curry function which uses this function as it's base.

--- a/src/api/iterable.cc
+++ b/src/api/iterable.cc
@@ -15,26 +15,25 @@ namespace tempearly
     TEMPEARLY_NATIVE_METHOD(iterable_first)
     {
         Value iterator = args[0].Call(interpreter, "__iter__");
+        Value element;
 
-        if (iterator)
+        if (!iterator)
         {
-            Value element;
-
-            if (iterator.GetNext(interpreter, element))
+            return;
+        }
+        else if (iterator.GetNext(interpreter, element))
+        {
+            frame->SetReturnValue(element);
+        }
+        else if (!interpreter->HasException())
+        {
+            if (args.GetSize() > 1)
             {
-                return element;
-            }
-            else if (!interpreter->HasException())
-            {
-                if (args.GetSize() > 1)
-                {
-                    return args[1];
-                }
+                frame->SetReturnValue(args[1]);
+            } else {
                 interpreter->Throw(interpreter->eStateError, "Iteration is empty");
             }
         }
-
-        return Value();
     }
 
     /**
@@ -52,26 +51,25 @@ namespace tempearly
 
         if (!iterator)
         {
-            return Value();
+            return;
         }
         else if (iterator.GetNext(interpreter, element))
         {
             while (iterator.GetNext(interpreter, element));
             if (!interpreter->HasException())
             {
-                return element;
+                frame->SetReturnValue(element);
             }
         }
         else if (!interpreter->HasException())
         {
             if (args.GetSize() > 1)
             {
-                return args[1];
+                frame->SetReturnValue(args[1]);
+            } else {
+                interpreter->Throw(interpreter->eStateError, "Iteration is empty");
             }
-            interpreter->Throw(interpreter->eStateError, "Iteration is empty");
         }
-
-        return Value();
     }
 
     /**
@@ -89,33 +87,31 @@ namespace tempearly
 
         if (!iterator)
         {
-            return Value();
+            return;
         }
-        if (iterator.GetNext(interpreter, element))
+        else if (iterator.GetNext(interpreter, element))
         {
             Value remaining;
 
             if (iterator.GetNext(interpreter, remaining))
             {
                 interpreter->Throw(interpreter->eStateError, "Iteration contains more than one element");
-
-                return Value();
+                return;
             }
             if (!interpreter->HasException())
             {
-                return element;
+                frame->SetReturnValue(element);
             }
         }
         else if (!interpreter->HasException())
         {
             if (args.GetSize() > 1)
             {
-                return args[1];
+                frame->SetReturnValue(args[1]);
+            } else {
+                interpreter->Throw(interpreter->eStateError, "Iteration is empty");
             }
-            interpreter->Throw(interpreter->eStateError, "Iteration is empty");
         }
-
-        return Value();
     }
 
     /**
@@ -158,7 +154,7 @@ namespace tempearly
                         if (!(result = element.Call(interpreter, "__gt__", args2))
                             || !result.AsBool(interpreter, b))
                         {
-                            return Value();
+                            return;
                         }
                         else if (b)
                         {
@@ -177,7 +173,7 @@ namespace tempearly
                         if (!(result = args[1].Call(interpreter, "__call__", args2))
                             || !result.AsInt(interpreter, i))
                         {
-                            return Value();
+                            return;
                         }
                         else if (i > 0)
                         {
@@ -187,7 +183,7 @@ namespace tempearly
                 }
                 if (!interpreter->HasException())
                 {
-                    return max;
+                    frame->SetReturnValue(max);
                 }
             }
             else if (!interpreter->HasException())
@@ -195,8 +191,6 @@ namespace tempearly
                 interpreter->Throw(interpreter->eStateError, "Iteration is empty");
             }
         }
-
-        return Value();
     }
 
     /**
@@ -238,7 +232,7 @@ namespace tempearly
                         args2.PushBack(min);
                         if (!(result = element.Call(interpreter, "__lt__", args2)) || !result.AsBool(interpreter, b))
                         {
-                            return Value();
+                            return;
                         }
                         else if (b)
                         {
@@ -256,7 +250,7 @@ namespace tempearly
                         args2.PushBack(element);
                         if (!(result = args[1].Call(interpreter, "__call__", args2)) || !result.AsInt(interpreter, i))
                         {
-                            return Value();
+                            return;
                         }
                         else if (i < 0)
                         {
@@ -266,7 +260,7 @@ namespace tempearly
                 }
                 if (!interpreter->HasException())
                 {
-                    return min;
+                    frame->SetReturnValue(min);
                 }
             }
             else if (!interpreter->HasException())
@@ -274,8 +268,6 @@ namespace tempearly
                 interpreter->Throw(interpreter->eStateError, "Iteration is empty");
             }
         }
-
-        return Value();
     }
 
     /**
@@ -300,7 +292,7 @@ namespace tempearly
 
         if (!iterator)
         {
-            return Value();
+            return;
         }
         if (iterator.GetNext(interpreter, element))
         {
@@ -317,7 +309,7 @@ namespace tempearly
                     args2.PushBack(element);
                     if (!(sum = sum.Call(interpreter, "__add__", args2)))
                     {
-                        return Value();
+                        return;
                     }
                     ++count;
                 }
@@ -330,7 +322,7 @@ namespace tempearly
                     args2.PushBack(element);
                     if (!(sum = args[1].Call(interpreter, "__call__", args2)))
                     {
-                        return Value();
+                        return;
                     }
                     ++count;
                 }
@@ -339,16 +331,13 @@ namespace tempearly
             {
                 args2.Clear();
                 args2.PushBack(Value::NewInt(count));
-
-                return sum.Call(interpreter, "__div__", args2);
+                frame->SetReturnValue(sum.Call(interpreter, "__div__", args2));
             }
         }
         else if (!interpreter->HasException())
         {
             interpreter->Throw(interpreter->eStateError, "Iteration is empty");
         }
-
-        return Value();
     }
 
     /**
@@ -373,7 +362,7 @@ namespace tempearly
 
         if (!iterator)
         {
-            return Value();
+            return;
         }
         if (iterator.GetNext(interpreter, element))
         {
@@ -389,7 +378,7 @@ namespace tempearly
                     args2.PushBack(element);
                     if (!(sum = sum.Call(interpreter, "__add__", args2)))
                     {
-                        return Value();
+                        return;
                     }
                 }
             } else {
@@ -401,21 +390,19 @@ namespace tempearly
                     args2.PushBack(element);
                     if (!(sum = args[1].Call(interpreter, "__call__", args2)))
                     {
-                        return Value();
+                        return;
                     }
                 }
             }
             if (!interpreter->HasException())
             {
-                return sum;
+                frame->SetReturnValue(sum);
             }
         }
         else if (!interpreter->HasException())
         {
             interpreter->Throw(interpreter->eStateError, "Iteration is empty");
         }
-
-        return Value();
     }
 
     /**
@@ -434,7 +421,7 @@ namespace tempearly
 
         if (!iterator)
         {
-            return Value();
+            return;
         }
         if (iterator.GetNext(interpreter, element))
         {
@@ -445,26 +432,23 @@ namespace tempearly
 
                 if (!result || !result.AsBool(interpreter, b))
                 {
-                    return Value();
+                    return;
                 }
                 else if (!b)
                 {
-                    return Value::NewBool(false);
+                    frame->SetReturnValue(Value::NewBool(false));
+                    return;
                 }
             }
             while (iterator.GetNext(interpreter, element));
-            if (interpreter->HasException())
+            if (!interpreter->HasException())
             {
-                return Value();
+                frame->SetReturnValue(Value::NewBool(true));
             }
-
-            return Value::NewBool(true);
         }
-        else if (interpreter->HasException())
+        else if (!interpreter->HasException())
         {
-            return Value();
-        } else {
-            return Value::NewBool(false);
+            frame->SetReturnValue(Value::NewBool(false));
         }
     }
 
@@ -484,7 +468,7 @@ namespace tempearly
 
         if (!iterator)
         {
-            return Value();
+            return;
         }
         if (iterator.GetNext(interpreter, element))
         {
@@ -495,21 +479,20 @@ namespace tempearly
 
                 if (!result || !result.AsBool(interpreter, b))
                 {
-                    return Value();
+                    return;
                 }
                 else if (b)
                 {
-                    return Value::NewBool(true);
+                    frame->SetReturnValue(Value::NewBool(true));
+                    return;
                 }
             }
             while (iterator.GetNext(interpreter, element));
         }
-        if (interpreter->HasException())
+        if (!interpreter->HasException())
         {
-            return Value();
+            frame->SetReturnValue(Value::NewBool(false));
         }
-
-        return Value::NewBool(false);
     }
 
     /**
@@ -530,16 +513,14 @@ namespace tempearly
             {
                 if (!args[1].Call(interpreter, "__call__", element))
                 {
-                    return Value();
+                    return;
                 }
             }
             if (!interpreter->HasException())
             {
-                return args[0];
+                frame->SetReturnValue(args[0]);
             }
         }
-
-        return Value();
     }
 
     /**
@@ -566,7 +547,7 @@ namespace tempearly
 
                 if (!result || !result.AsBool(interpreter, b))
                 {
-                    return Value();
+                    return;
                 }
                 else if (b)
                 {
@@ -575,11 +556,9 @@ namespace tempearly
             }
             if (!interpreter->HasException())
             {
-                return Value(list);
+                frame->SetReturnValue(Value(list));
             }
         }
-
-        return Value();
     }
 
     /**
@@ -606,7 +585,7 @@ namespace tempearly
 
                 if (!result || !result.AsBool(interpreter, b))
                 {
-                    return Value();
+                    return;
                 }
                 else if (b)
                 {
@@ -615,11 +594,9 @@ namespace tempearly
             }
             if (!interpreter->HasException())
             {
-                return Value(list);
+                frame->SetReturnValue(Value(list));
             }
         }
-
-        return Value();
     }
 
     /**
@@ -647,19 +624,18 @@ namespace tempearly
                 {
                     if (b)
                     {
-                        return Value::NewBool(true);
+                        frame->SetReturnValue(Value::NewBool(true));
+                        return;
                     }
                 } else {
-                    return Value();
+                    return;
                 }
             }
             if (!interpreter->HasException())
             {
-                return Value::NewBool(false);
+                frame->SetReturnValue(Value::NewBool(false));
             }
         }
-
-        return Value();
     }
 
     /**
@@ -684,12 +660,11 @@ namespace tempearly
         {
             if (!args[1].AsString(interpreter, separator))
             {
-                return Value();
+                return;
             }
         } else {
             interpreter->Throw(interpreter->eValueError, "Too many arguments");
-
-            return Value();
+            return;
         }
         if (!args[0].HasFlag(CountedObject::FLAG_INSPECTING))
         {
@@ -701,8 +676,7 @@ namespace tempearly
             if (!(iterator = args[0].Call(interpreter, "__iter__")))
             {
                 args[0].UnsetFlag(CountedObject::FLAG_INSPECTING);
-
-                return Value();
+                return;
             }
             while (iterator.GetNext(interpreter, element))
             {
@@ -711,8 +685,7 @@ namespace tempearly
                 if (!element.ToString(interpreter, repr))
                 {
                     args[0].UnsetFlag(CountedObject::FLAG_INSPECTING);
-
-                    return Value();
+                    return;
                 }
                 if (first)
                 {
@@ -725,11 +698,10 @@ namespace tempearly
             args[0].UnsetFlag(CountedObject::FLAG_INSPECTING);
             if (interpreter->HasException())
             {
-                return Value();
+                return;
             }
         }
-
-        return Value::NewString(buffer.ToString());
+        frame->SetReturnValue(Value::NewString(buffer.ToString()));
     }
 
     /**
@@ -755,17 +727,15 @@ namespace tempearly
 
                 if (!result)
                 {
-                    return Value();
+                    return;
                 }
                 list->Append(result);
             }
             if (!interpreter->HasException())
             {
-                return Value(list);
+                frame->SetReturnValue(Value(list));
             }
         }
-
-        return Value();
     }
 
     static bool quicksort(const Handle<Interpreter>& interpreter,
@@ -952,8 +922,7 @@ namespace tempearly
                         Handle<ListObject> list = new ListObject(interpreter->cList);
 
                         list->Append(vector);
-
-                        return Value(list);
+                        frame->SetReturnValue(Value(list));
                     }
                 }
                 else if (quicksort_callback(interpreter, vector, 0, vector.GetSize(), args[1]))
@@ -961,13 +930,10 @@ namespace tempearly
                     Handle<ListObject> list = new ListObject(interpreter->cList);
 
                     list->Append(vector);
-
-                    return Value(list);
+                    frame->SetReturnValue(Value(list));
                 }
             }
         }
-
-        return Value();
     }
 
     /**
@@ -1000,7 +966,7 @@ namespace tempearly
 
                 if (!result || !result.AsBool(interpreter, slot))
                 {
-                    return Value();
+                    return;
                 }
                 else if (slot)
                 {
@@ -1013,12 +979,9 @@ namespace tempearly
             {
                 result->Append(Value(a));
                 result->Append(Value(b));
-
-                return Value(result);
+                frame->SetReturnValue(Value(result));
             }
         }
-
-        return Value();
     }
 
     /**
@@ -1038,32 +1001,29 @@ namespace tempearly
         
         if (!args[1].AsInt(interpreter, count))
         {
-            return Value();
+            return;
         }
         else if (count < 0)
         {
             interpreter->Throw(interpreter->eValueError, "Negative count");
-
-            return Value();
+            return;
         }
         else if (!(iterator = args[0].Call(interpreter, "__iter__")))
         {
-            return Value();
+            return;
         }
         while (count-- > 0)
         {
             if (!iterator.GetNext(interpreter, element))
             {
-                if (interpreter->HasException())
+                if (!interpreter->HasException())
                 {
-                    return Value();
-                } else {
-                    return iterator;
+                    frame->SetReturnValue(iterator);
                 }
+                return;
             }
         }
-
-        return iterator;
+        frame->SetReturnValue(iterator);
     }
 
     /**
@@ -1086,8 +1046,7 @@ namespace tempearly
             if (!(iterator = args[0].Call(interpreter, "__iter__")))
             {
                 args[0].UnsetFlag(CountedObject::FLAG_INSPECTING);
-
-                return Value();
+                return;
             }
             while (iterator.GetNext(interpreter, element))
             {
@@ -1097,8 +1056,7 @@ namespace tempearly
                 if (!result || !result.AsString(interpreter, json))
                 {
                     args[0].UnsetFlag(CountedObject::FLAG_INSPECTING);
-
-                    return Value();
+                    return;
                 }
                 if (first)
                 {
@@ -1111,12 +1069,11 @@ namespace tempearly
             args[0].UnsetFlag(CountedObject::FLAG_INSPECTING);
             if (interpreter->HasException())
             {
-                return Value();
+                return;
             }
         }
         buffer << ']';
-
-        return Value::NewString(buffer.ToString());
+        frame->SetReturnValue(Value::NewString(buffer.ToString()));
     }
 
     void init_iterable(Interpreter* i)

--- a/src/api/iterator.cc
+++ b/src/api/iterator.cc
@@ -26,8 +26,7 @@ namespace tempearly
                 case Result::KIND_BREAK:
                     if (!interpreter->HasException())
                     {
-                        interpreter->Throw(interpreter->eStopIteration,
-                                           "Iteration reached end");
+                        interpreter->Throw(interpreter->eStopIteration, "Iteration reached end");
                     }
 
                 default:
@@ -104,7 +103,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iter_next)
     {
-        return args[0].As<IteratorObject>()->Next(interpreter);
+        frame->SetReturnValue(args[0].As<IteratorObject>()->Next(interpreter));
     }
 
     /**
@@ -128,8 +127,7 @@ namespace tempearly
         {
             iterator->Feed(args[i]);
         }
-
-        return args[0];
+        frame->SetReturnValue(args[0]);
     }
 
     /**
@@ -146,7 +144,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iter_peek)
     {
-        return args[0].As<IteratorObject>()->Peek(interpreter);
+        frame->SetReturnValue(args[0].As<IteratorObject>()->Peek(interpreter));
     }
 
     /**
@@ -156,7 +154,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iter_iter)
     {
-        return args[0];
+        frame->SetReturnValue(args[0]);
     }
 
     /**
@@ -169,15 +167,12 @@ namespace tempearly
     {
         if (args[0].As<IteratorObject>()->Peek(interpreter))
         {
-            return Value::NewBool(true);
+            frame->SetReturnValue(Value::NewBool(true));
         }
         else if (interpreter->GetException().IsInstance(interpreter, interpreter->eStopIteration))
         {
             interpreter->ClearException();
-
-            return Value::NewBool(false);
-        } else {
-            return Value();
+            frame->SetReturnValue(Value::NewBool(false));
         }
     }
 

--- a/src/api/list.cc
+++ b/src/api/list.cc
@@ -159,8 +159,6 @@ namespace tempearly
         {
             list->Append(args.SubVector(1));
         }
-
-        return Value::NullValue();
     }
 
     /**
@@ -170,7 +168,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(list_size)
     {
-        return Value::NewInt(args[0].As<ListObject>()->GetSize());
+        frame->SetReturnValue(Value::NewInt(args[0].As<ListObject>()->GetSize()));
     }
 
     /**
@@ -186,8 +184,7 @@ namespace tempearly
         {
             args[0].As<ListObject>()->Append(args.SubVector(1));
         }
-
-        return args[0];
+        frame->SetReturnValue(args[0]);
     }
 
     /**
@@ -203,8 +200,7 @@ namespace tempearly
         {
             args[0].As<ListObject>()->Prepend(args.SubVector(1));
         }
-
-        return args[0];
+        frame->SetReturnValue(args[0]);
     }
 
     /**
@@ -215,8 +211,7 @@ namespace tempearly
     TEMPEARLY_NATIVE_METHOD(list_clear)
     {
         args[0].As<ListObject>()->Clear();
-
-        return args[0];
+        frame->SetReturnValue(args[0]);
     }
 
     namespace
@@ -274,8 +269,7 @@ namespace tempearly
         } else {
             iterator = new ListIterator(interpreter->cIterator, list);
         }
-
-        return Value(iterator);
+        frame->SetReturnValue(Value(iterator));
     }
 
     /**
@@ -297,7 +291,7 @@ namespace tempearly
 
         if (!iterator)
         {
-            return Value();
+            return;
         }
         result = new ListObject(interpreter->cList);
         result->Append(original);
@@ -305,12 +299,10 @@ namespace tempearly
         {
             result->Append(element);
         }
-        if (interpreter->HasException())
+        if (!interpreter->HasException())
         {
-            return Value();
+            frame->SetReturnValue(Value(result));
         }
-
-        return Value(result);
     }
 
     /**
@@ -320,7 +312,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(list_bool)
     {
-        return Value::NewBool(!args[0].As<ListObject>()->IsEmpty());
+        frame->SetReturnValue(Value::NewBool(!args[0].As<ListObject>()->IsEmpty()));
     }
 
     void init_list(Interpreter* i)

--- a/src/api/map.cc
+++ b/src/api/map.cc
@@ -127,7 +127,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(map_size)
     {
-        return Value::NewInt(args[0].As<MapObject>()->GetSize());
+        frame->SetReturnValue(Value::NewInt(args[0].As<MapObject>()->GetSize()));
     }
 
     /**
@@ -146,8 +146,7 @@ namespace tempearly
         {
             set->Add(e->GetHash(), e->GetKey());
         }
-
-        return Value(set);
+        frame->SetReturnValue(Value(set));
     }
 
     /**
@@ -166,8 +165,7 @@ namespace tempearly
         {
             list->Append(e->GetValue());
         }
-
-        return Value(list);
+        frame->SetReturnValue(Value(list));
     }
 
     /**
@@ -181,9 +179,7 @@ namespace tempearly
 
         if (args[1].GetHash(interpreter, hash))
         {
-            return Value::NewBool(args[0].As<MapObject>()->Find(hash));
-        } else {
-            return Value();
+            frame->SetReturnValue(Value::NewBool(args[0].As<MapObject>()->Find(hash)));
         }
     }
 
@@ -205,16 +201,12 @@ namespace tempearly
 
             if (value)
             {
-                return value;
+                frame->SetReturnValue(value);
             }
             else if (args.GetSize() > 2)
             {
-                return args[2];
-            } else {
-                return Value::NullValue();
+                frame->SetReturnValue(args[2]);
             }
-        } else {
-            return Value();
         }
     }
 
@@ -226,8 +218,7 @@ namespace tempearly
     TEMPEARLY_NATIVE_METHOD(map_clear)
     {
         args[0].As<MapObject>()->Clear();
-
-        return args[0];
+        frame->SetReturnValue(args[0]);
     }
 
     /**
@@ -260,7 +251,7 @@ namespace tempearly
                 }
                 else if (!args[1].AsString(interpreter, sep1))
                 {
-                    return Value();
+                    return;
                 }
                 if (args.GetSize() > 2)
                 {
@@ -270,7 +261,7 @@ namespace tempearly
                     }
                     else if (!args[2].AsString(interpreter, sep2))
                     {
-                        return Value();
+                        return;
                     }
                 } else {
                     sep2 = ", ";
@@ -291,22 +282,19 @@ namespace tempearly
                 if (!entry->GetKey().ToString(interpreter, string))
                 {
                     map->UnsetFlag(CountedObject::FLAG_INSPECTING);
-
-                    return Value();
+                    return;
                 }
                 buffer << string << sep1;
                 if (!entry->GetValue().ToString(interpreter, string))
                 {
                     map->UnsetFlag(CountedObject::FLAG_INSPECTING);
-
-                    return Value();
+                    return;
                 }
                 buffer.Append(string);
             }
             map->UnsetFlag(CountedObject::FLAG_INSPECTING);
         }
-
-        return Value::NewString(buffer.ToString());
+        frame->SetReturnValue(Value::NewString(buffer.ToString()));
     }
 
     /**
@@ -322,16 +310,14 @@ namespace tempearly
         if (!args[1].IsMap())
         {
             interpreter->Throw(interpreter->eValueError, "Map required");
-
-            return Value();
+            return;
         }
         other = args[1].As<MapObject>();
         for (Handle<MapObject::Entry> entry = other->GetFront(); entry; entry = entry->GetNext())
         {
             map->Insert(entry->GetHash(), entry->GetKey(), entry->GetValue());
         }
-
-        return args[0];
+        frame->SetReturnValue(args[0]);
     }
 
     namespace
@@ -397,8 +383,7 @@ namespace tempearly
         } else {
             iterator = new MapIterator(interpreter, map);
         }
-
-        return Value(iterator);
+        frame->SetReturnValue(Value(iterator));
     }
 
     /**
@@ -419,12 +404,10 @@ namespace tempearly
 
             if (value)
             {
-                return value;
+                frame->SetReturnValue(value);
             } else {
-                return args[0].Call(interpreter, "__missing__", args[1]);
+                frame->SetReturnValue(args[0].Call(interpreter, "__missing__", args[1]));
             }
-        } else {
-            return Value();
         }
     }
 
@@ -448,11 +431,10 @@ namespace tempearly
 
         if (!key.GetHash(interpreter, hash))
         {
-            return Value();
+            return;
         }
         args[0].As<MapObject>()->Insert(hash, key, value);
-
-        return args[0];
+        frame->SetReturnValue(args[0]);
     }
 
     /**
@@ -469,8 +451,6 @@ namespace tempearly
         {
             interpreter->Throw(interpreter->eKeyError, repr);
         }
-
-        return Value();
     }
 
     /**
@@ -481,7 +461,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(map_bool)
     {
-        return Value::NewBool(!args[0].As<MapObject>()->IsEmpty());
+        frame->SetReturnValue(Value::NewBool(!args[0].As<MapObject>()->IsEmpty()));
     }
 
     /**
@@ -511,8 +491,7 @@ namespace tempearly
                     || !result.AsString(interpreter, value))
                 {
                     map->UnsetFlag(CountedObject::FLAG_INSPECTING);
-
-                    return Value();
+                    return;
                 }
                 if (first)
                 {
@@ -525,8 +504,7 @@ namespace tempearly
             map->UnsetFlag(CountedObject::FLAG_INSPECTING);
         }
         buffer << '}';
-
-        return Value::NewString(buffer.ToString());
+        frame->SetReturnValue(Value::NewString(buffer.ToString()));
     }
 
     /**
@@ -543,8 +521,7 @@ namespace tempearly
         if (!args[1].IsMap())
         {
             interpreter->Throw(interpreter->eValueError, "Map required");
-
-            return Value();
+            return;
         }
         result = new MapObject(interpreter->cMap);
         for (Handle<MapObject::Entry> entry = map->GetFront(); entry; entry = entry->GetNext())
@@ -556,8 +533,7 @@ namespace tempearly
         {
             result->Insert(entry->GetHash(), entry->GetKey(), entry->GetValue());
         }
-
-        return Value(result);
+        frame->SetReturnValue(Value(result));
     }
 
     void init_map(Interpreter* i)

--- a/src/api/number.cc
+++ b/src/api/number.cc
@@ -26,22 +26,18 @@ namespace tempearly
             {
                 if (max > 1)
                 {
-                    return Value::NewInt(Random::NextU64() % max);
+                    frame->SetReturnValue(Value::NewInt(Random::NextU64() % max));
                 }
                 else if (max == 0)
                 {
-                    interpreter->Throw(interpreter->eValueError,
-                                       "Max cannot be zero");
+                    interpreter->Throw(interpreter->eValueError, "Max cannot be zero");
                 } else {
-                    interpreter->Throw(interpreter->eValueError,
-                                       "Max cannot be negative");
+                    interpreter->Throw(interpreter->eValueError, "Max cannot be negative");
                 }
             }
-
-            return Value();
+        } else {
+            frame->SetReturnValue(Value::NewInt(Random::NextU64()));
         }
-
-        return Value::NewInt(Random::NextU64());
     }
 
     /**
@@ -59,17 +55,15 @@ namespace tempearly
         {
             if (!args[1].AsInt(interpreter, radix))
             {
-                return Value();
+                return;
             }
             else if (radix < 2 || radix > 36)
             {
                 interpreter->Throw(interpreter->eValueError, "Invalid radix");
-
-                return Value();
+                return;
             }
         }
-
-        return Value::NewString(Utils::ToString(args[0].AsInt(), radix));
+        frame->SetReturnValue(Value::NewString(Utils::ToString(args[0].AsInt(), radix)));
     }
 
     /**
@@ -88,16 +82,14 @@ namespace tempearly
             const double a = self.AsFloat();
             const double b = operand.AsFloat();
 
-            return Value::NewFloat(a + b);
+            frame->SetReturnValue(Value::NewFloat(a + b));
         } else {
             const i64 a = self.AsInt();
             i64 b;
 
             if (operand.AsInt(interpreter, b))
             {
-                return Value::NewInt(a + b);
-            } else {
-                return Value();
+                frame->SetReturnValue(Value::NewInt(a + b));
             }
         }
     }
@@ -118,16 +110,14 @@ namespace tempearly
             const double a = self.AsFloat();
             const double b = operand.AsFloat();
 
-            return Value::NewFloat(a - b);
+            frame->SetReturnValue(Value::NewFloat(a - b));
         } else {
             const i64 a = self.AsInt();
             i64 b;
 
             if (operand.AsInt(interpreter, b))
             {
-                return Value::NewInt(a - b);
-            } else {
-                return Value();
+                frame->SetReturnValue(Value::NewInt(a - b));
             }
         }
     }
@@ -148,16 +138,14 @@ namespace tempearly
             const double a = self.AsFloat();
             const double b = operand.AsFloat();
 
-            return Value::NewFloat(a * b);
+            frame->SetReturnValue(Value::NewFloat(a * b));
         } else {
             const i64 a = self.AsInt();
             i64 b;
 
             if (operand.AsInt(interpreter, b))
             {
-                return Value::NewInt(a * b);
-            } else {
-                return Value();
+                frame->SetReturnValue(Value::NewInt(a * b));
             }
         }
     }
@@ -178,13 +166,11 @@ namespace tempearly
         {
             if (b != 0.0)
             {
-                return Value::NewFloat(a / b);
+                frame->SetReturnValue(Value::NewFloat(a / b));
+            } else {
+                interpreter->Throw(interpreter->eZeroDivisionError, "Division by zero");
             }
-            interpreter->Throw(interpreter->eZeroDivisionError,
-                               "Division by zero");
         }
-
-        return Value();
     }
 
     /**
@@ -203,14 +189,11 @@ namespace tempearly
         {
             if (b == 0)
             {
-                interpreter->Throw(interpreter->eZeroDivisionError,
-                                   "Division by zero");
+                interpreter->Throw(interpreter->eZeroDivisionError, "Division by zero");
             } else {
-                return Value::NewInt(a % b);
+                frame->SetReturnValue(Value::NewInt(a % b));
             }
         }
-        
-        return Value();
     }
 
     /**
@@ -225,9 +208,7 @@ namespace tempearly
 
         if (args[1].AsInt(interpreter, b))
         {
-            return Value::NewInt(a & b);
-        } else {
-            return Value();
+            frame->SetReturnValue(Value::NewInt(a & b));
         }
     }
 
@@ -243,9 +224,7 @@ namespace tempearly
 
         if (args[1].AsInt(interpreter, b))
         {
-            return Value::NewInt(a | b);
-        } else {
-            return Value();
+            frame->SetReturnValue(Value::NewInt(a | b));
         }
     }
 
@@ -261,9 +240,7 @@ namespace tempearly
 
         if (args[1].AsInt(interpreter, b))
         {
-            return Value::NewInt(a ^ b);
-        } else {
-            return Value();
+            frame->SetReturnValue(Value::NewInt(a ^ b));
         }
     }
 
@@ -279,9 +256,7 @@ namespace tempearly
 
         if (args[1].AsInt(interpreter, b))
         {
-            return Value::NewInt(b < 0 ? a >> -b : a << b);
-        } else {
-            return Value();
+            frame->SetReturnValue(Value::NewInt(b < 0 ? a >> -b : a << b));
         }
     }
 
@@ -297,9 +272,7 @@ namespace tempearly
 
         if (args[1].AsInt(interpreter, b))
         {
-            return Value::NewInt(b < 0 ? a << -b : a >> b);
-        } else {
-            return Value();
+            frame->SetReturnValue(Value::NewInt(b < 0 ? a << -b : a >> b));
         }
     }
 
@@ -316,13 +289,13 @@ namespace tempearly
 
         if (operand.IsInt())
         {
-            return Value::NewBool(self.AsInt() == operand.AsInt());
+            frame->SetReturnValue(Value::NewBool(self.AsInt() == operand.AsInt()));
         }
         else if (operand.IsFloat())
         {
-            return Value::NewBool(static_cast<double>(self.AsFloat()) == operand.AsFloat());
+            frame->SetReturnValue(Value::NewBool(static_cast<double>(self.AsFloat()) == operand.AsFloat()));
         } else {
-            return Value::NewBool(false);
+            frame->SetReturnValue(Value::NewBool(false));
         }
     }
 
@@ -342,18 +315,17 @@ namespace tempearly
 
         if (operand.IsInt())
         {
-            return Value::NewBool(self.AsInt() < operand.AsInt());
+            frame->SetReturnValue(Value::NewBool(self.AsInt() < operand.AsInt()));
         }
         else if (operand.IsFloat())
         {
-            return Value::NewBool(static_cast<double>(self.AsInt()) < operand.AsFloat());
+            frame->SetReturnValue(Value::NewBool(static_cast<double>(self.AsInt()) < operand.AsFloat()));
+        } else {
+            interpreter->Throw(
+                interpreter->eTypeError,
+                "Cannot compare '" + operand.GetClass(interpreter)->GetName() + "' with 'Int'"
+            );
         }
-        interpreter->Throw(
-            interpreter->eTypeError,
-            "Cannot compare '" + operand.GetClass(interpreter)->GetName() + "' with 'Int'"
-        );
-
-        return Value();
     }
 
     /**
@@ -363,7 +335,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(int_inc)
     {
-        return Value::NewInt(args[0].AsInt() + 1);
+        frame->SetReturnValue(Value::NewInt(args[0].AsInt() + 1));
     }
 
     /**
@@ -373,7 +345,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(int_dec)
     {
-        return Value::NewInt(args[0].AsInt() - 1);
+        frame->SetReturnValue(Value::NewInt(args[0].AsInt() - 1));
     }
 
     /**
@@ -383,7 +355,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(int_neg)
     {
-        return Value::NewInt(-args[0].AsInt());
+        frame->SetReturnValue(Value::NewInt(-args[0].AsInt()));
     }
 
     /**
@@ -393,7 +365,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(int_invert)
     {
-        return Value::NewInt(~args[0].AsInt());
+        frame->SetReturnValue(Value::NewInt(~args[0].AsInt()));
     }
 
     /**
@@ -411,17 +383,14 @@ namespace tempearly
             {
                 if (max > 0)
                 {
-                    return Value::NewFloat(Random::NextDouble() * max);
+                    frame->SetReturnValue(Value::NewFloat(Random::NextDouble() * max));
                 } else {
-                    interpreter->Throw(interpreter->eValueError,
-                                      "Max cannot be negative or zero");
+                    interpreter->Throw(interpreter->eValueError, "Max cannot be negative or zero");
                 }
             }
-
-            return Value();
+        } else {
+            frame->SetReturnValue(Value::NewFloat(Random::NextDouble()));
         }
-
-        return Value::NewFloat(Random::NextDouble());
     }
 
     /**
@@ -431,7 +400,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(flo_str)
     {
-        return Value::NewString(Utils::ToString(args[0].AsFloat()));
+        frame->SetReturnValue(Value::NewString(Utils::ToString(args[0].AsFloat())));
     }
 
     /**
@@ -446,9 +415,7 @@ namespace tempearly
 
         if (args[1].AsFloat(interpreter, b))
         {
-            return Value::NewFloat(a + b);
-        } else {
-            return Value();
+            frame->SetReturnValue(Value::NewFloat(a + b));
         }
     }
 
@@ -464,9 +431,7 @@ namespace tempearly
 
         if (args[1].AsFloat(interpreter, b))
         {
-            return Value::NewFloat(a - b);
-        } else {
-            return Value();
+            frame->SetReturnValue(Value::NewFloat(a - b));
         }
     }
 
@@ -482,9 +447,7 @@ namespace tempearly
 
         if (args[1].AsFloat(interpreter, b))
         {
-            return Value::NewFloat(a * b);
-        } else {
-            return Value();
+            frame->SetReturnValue(Value::NewFloat(a * b));
         }
     }
 
@@ -504,13 +467,11 @@ namespace tempearly
         {
             if (b != 0.0)
             {
-                return Value::NewFloat(a / b);
+                frame->SetReturnValue(Value::NewFloat(a / b));
+            } else {
+                interpreter->Throw(interpreter->eZeroDivisionError, "Float division by zero");
             }
-            interpreter->Throw(interpreter->eZeroDivisionError,
-                               "Float division by zero");
         }
-
-        return Value();
     }
 
     /**
@@ -537,14 +498,11 @@ namespace tempearly
                     mod += b;
                     div -= 1.0;
                 }
-
-                return Value::NewFloat(mod);
+                frame->SetReturnValue(Value::NewFloat(mod));
+            } else {
+                interpreter->Throw(interpreter->eZeroDivisionError, "Float modulo");
             }
-            interpreter->Throw(interpreter->eZeroDivisionError,
-                               "Float modulo");
         }
-
-        return Value();
     }
 
     /**
@@ -557,12 +515,13 @@ namespace tempearly
     {
         const Value& operand = args[1];
 
-        if (operand.IsFloat() || operand.IsInt())
-        {
-            return Value::NewBool(args[0].AsFloat() == operand.AsFloat());
-        } else {
-            return Value::NewBool(false);
-        }
+        frame->SetReturnValue(
+            Value::NewBool(
+                operand.IsFloat() || operand.IsInt() ?
+                args[0].AsFloat() == operand.AsFloat() :
+                false
+            )
+        );
     }
 
     /**
@@ -580,14 +539,13 @@ namespace tempearly
 
         if (operand.IsFloat() || operand.IsInt())
         {
-            return Value::NewBool(args[0].AsFloat() < operand.AsFloat());
+            frame->SetReturnValue(Value::NewBool(args[0].AsFloat() < operand.AsFloat()));
+        } else {
+            interpreter->Throw(
+                interpreter->eTypeError,
+                "Cannot compare '" + operand.GetClass(interpreter)->GetName() + "' with 'Float'"
+            );
         }
-        interpreter->Throw(
-            interpreter->eTypeError,
-            "Cannot compare '" + operand.GetClass(interpreter)->GetName() + "' with 'Float'"
-        );
-
-        return Value();
     }
 
     /**
@@ -597,7 +555,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(flo_inc)
     {
-        return Value::NewFloat(args[0].AsFloat() + 1.0);
+        frame->SetReturnValue(Value::NewFloat(args[0].AsFloat() + 1.0));
     }
 
     /**
@@ -607,7 +565,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(flo_dec)
     {
-        return Value::NewFloat(args[0].AsFloat() - 1.0);
+        frame->SetReturnValue(Value::NewFloat(args[0].AsFloat() - 1.0));
     }
 
     /**
@@ -617,7 +575,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(flo_neg)
     {
-        return Value::NewFloat(-args[0].AsFloat());
+        frame->SetReturnValue(Value::NewFloat(-args[0].AsFloat()));
     }
 
     void init_number(Interpreter* i)

--- a/src/api/object.cc
+++ b/src/api/object.cc
@@ -79,10 +79,7 @@ namespace tempearly
      *
      * Works as constructor or initializer for the object.
      */
-    TEMPEARLY_NATIVE_METHOD(obj_init)
-    {
-        return Value::NullValue();
-    }
+    TEMPEARLY_NATIVE_METHOD(obj_init) {}
 
     /**
      * Object#__hash__() => Int
@@ -97,11 +94,11 @@ namespace tempearly
         if (args[0].Is(Value::KIND_OBJECT))
         {
             Handle<CoreObject> object = args[0].AsObject();
-
-            return Value::NewInt(reinterpret_cast<u64>(object.Get()));
+            
+            frame->SetReturnValue(Value::NewInt(reinterpret_cast<u64>(object.Get())));
+        } else {
+            frame->SetReturnValue(Value::NewInt(0));
         }
-
-        return Value::NewInt(0);
     }
 
     /**
@@ -111,13 +108,13 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(obj_bool)
     {
-        const Value& self = args[0];
+        const Value& receiver = args[0];
 
-        if (self.IsBool())
+        if (receiver.IsBool())
         {
-            return self;
+            frame->SetReturnValue(receiver);
         } else {
-            return Value::NewBool(!self.IsNull());
+            frame->SetReturnValue(Value::NewBool(!receiver.IsNull()));
         }
     }
 
@@ -128,13 +125,13 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(obj_str)
     {
-        const Value& self = args[0];
+        const Value& receiver = args[0];
 
-        if (self.IsString())
+        if (receiver.IsString())
         {
-            return self;
+            frame->SetReturnValue(receiver);
         } else {
-            return Value::NewString("<object>");
+            frame->SetReturnValue(Value::NewString("<object>"));
         }
     }
 
@@ -165,8 +162,7 @@ namespace tempearly
                 if (!(result = entry->GetValue().Call(interpreter, "as_json")) || !result.AsString(interpreter, value))
                 {
                     self.UnsetFlag(CountedObject::FLAG_INSPECTING);
-
-                    return Value();
+                    return;
                 }
                 if (first)
                 {
@@ -179,8 +175,7 @@ namespace tempearly
             self.UnsetFlag(CountedObject::FLAG_INSPECTING);
         }
         buffer << '}';
-
-        return Value::NewString(buffer.ToString());
+        frame->SetReturnValue(Value::NewString(buffer.ToString()));
     }
 
     /**
@@ -211,8 +206,7 @@ namespace tempearly
         } else {
             result = false;
         }
-
-        return Value::NewBool(result);
+        frame->SetReturnValue(Value::NewBool(result));
     }
 
     /**
@@ -230,17 +224,15 @@ namespace tempearly
 
         if (!self.IsLessThan(interpreter, operand, slot))
         {
-            return Value();
+            return;
         }
         else if (slot)
         {
-            return Value::NewBool(false);
+            frame->SetReturnValue(Value::NewBool(false));
         }
-        else if (!self.Equals(interpreter, operand, slot))
+        else if (self.Equals(interpreter, operand, slot))
         {
-            return Value();
-        } else {
-            return Value::NewBool(!slot);
+            frame->SetReturnValue(Value::NewBool(!slot));
         }
     }
 
@@ -259,17 +251,15 @@ namespace tempearly
 
         if (!self.IsLessThan(interpreter, operand, slot))
         {
-            return Value();
+            return;
         }
         else if (slot)
         {
-            return Value::NewBool(true);
+            frame->SetReturnValue(Value::NewBool(true));
         }
-        else if (!self.Equals(interpreter, operand, slot))
+        else if (self.Equals(interpreter, operand, slot))
         {
-            return Value();
-        } else {
-            return Value::NewBool(slot);
+            frame->SetReturnValue(Value::NewBool(slot));
         }
     }
 
@@ -288,17 +278,15 @@ namespace tempearly
 
         if (!self.IsLessThan(interpreter, operand, slot))
         {
-            return Value();
+            return;
         }
         else if (slot)
         {
-            return Value::NewBool(false);
+            frame->SetReturnValue(Value::NewBool(false));
         }
-        else if (!self.Equals(interpreter, operand, slot))
+        else if (self.Equals(interpreter, operand, slot))
         {
-            return Value();
-        } else {
-            return Value::NewBool(slot);
+            frame->SetReturnValue(Value::NewBool(slot));
         }
     }
 

--- a/src/api/range.cc
+++ b/src/api/range.cc
@@ -34,10 +34,9 @@ namespace tempearly
 
         if (args.GetSize() > 2 && !args[2].AsBool(interpreter, exclusive))
         {
-            return Value();
+            return;
         }
-
-        return Value(new RangeObject(interpreter, begin, end, exclusive));
+        frame->SetReturnValue(Value(new RangeObject(interpreter, begin, end, exclusive)));
     }
 
     /**
@@ -49,7 +48,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(range_begin)
     {
-        return args[0].As<RangeObject>()->GetBegin();
+        frame->SetReturnValue(args[0].As<RangeObject>()->GetBegin());
     }
 
     /**
@@ -61,7 +60,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(range_end)
     {
-        return args[0].As<RangeObject>()->GetEnd();
+        frame->SetReturnValue(args[0].As<RangeObject>()->GetEnd());
     }
 
     /**
@@ -74,7 +73,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(range_is_exclusive)
     {
-        return Value::NewBool(args[0].As<RangeObject>()->IsExclusive());
+        frame->SetReturnValue(Value::NewBool(args[0].As<RangeObject>()->IsExclusive()));
     }
 
     namespace
@@ -196,8 +195,7 @@ namespace tempearly
                                          end,
                                          range->IsExclusive());
         }
-
-        return Value(iterator);
+        frame->SetReturnValue(Value(iterator));
     }
 
     /**
@@ -218,8 +216,7 @@ namespace tempearly
             if (!range->GetBegin().ToString(interpreter, string))
             {
                 range->UnsetFlag(CountedObject::FLAG_INSPECTING);
-
-                return Value();
+                return;
             }
             buffer << string << '.' << '.';
             if (range->IsExclusive())
@@ -229,14 +226,12 @@ namespace tempearly
             if (!range->GetEnd().ToString(interpreter, string))
             {
                 range->UnsetFlag(CountedObject::FLAG_INSPECTING);
-
-                return Value();
+                return;
             }
             range->UnsetFlag(CountedObject::FLAG_INSPECTING);
             buffer << string;
         }
-
-        return Value::NewString(buffer.ToString());
+        frame->SetReturnValue(Value::NewString(buffer.ToString()));
     }
 
     void init_range(Interpreter* i)

--- a/src/api/set.cc
+++ b/src/api/set.cc
@@ -134,12 +134,10 @@ namespace tempearly
 
             if (!object.GetHash(interpreter, hash))
             {
-                return Value();
+                return;
             }
             set->Add(hash, object);
         }
-
-        return Value::NullValue();
     }
 
     /**
@@ -149,7 +147,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(set_size)
     {
-        return Value::NewInt(args[0].As<SetObject>()->GetSize());
+        frame->SetReturnValue(Value::NewInt(args[0].As<SetObject>()->GetSize()));
     }
 
     namespace
@@ -206,8 +204,7 @@ namespace tempearly
         } else {
             iterator = new SetIterator(interpreter->cIterator, set);
         }
-
-        return Value(iterator);
+        frame->SetReturnValue(Value(iterator));
     }
 
     /**
@@ -232,8 +229,7 @@ namespace tempearly
             }
             set->UnsetFlag(Object::FLAG_INSPECTING);
         }
-
-        return Value::NewInt(hash);
+        frame->SetReturnValue(Value::NewInt(hash));
     }
 
     /**
@@ -248,9 +244,7 @@ namespace tempearly
 
         if (args[1].GetHash(interpreter, hash))
         {
-            return Value::NewBool(args[0].As<SetObject>()->Find(hash));
-        } else {
-            return Value();
+            frame->SetReturnValue(Value::NewBool(args[0].As<SetObject>()->Find(hash)));
         }
     }
 
@@ -270,12 +264,11 @@ namespace tempearly
 
             if (!object.GetHash(interpreter, hash))
             {
-                return Value();
+                return;
             }
             set->Add(hash, object);
         }
-
-        return args[0];
+        frame->SetReturnValue(args[0]);
     }
 
     /**
@@ -286,8 +279,7 @@ namespace tempearly
     TEMPEARLY_NATIVE_METHOD(set_clear)
     {
         args[0].As<SetObject>()->Clear();
-
-        return args[0];
+        frame->SetReturnValue(args[0]);
     }
 
     /**
@@ -310,23 +302,21 @@ namespace tempearly
 
         if (!iterator)
         {
-            return Value();
+            return;
         }
         result = new SetObject(interpreter->cSet, original);
         while (iterator.GetNext(interpreter, element))
         {
             if (!element.GetHash(interpreter, hash))
             {
-                return Value();
+                return;
             }
             result->Add(hash, element);
         }
-        if (interpreter->HasException())
+        if (!interpreter->HasException())
         {
-            return Value();
+            frame->SetReturnValue(Value(result));
         }
-
-        return Value(result);
     }
 
     /**
@@ -337,7 +327,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(set_bool)
     {
-        return Value::NewBool(!args[0].As<SetObject>()->IsEmpty());
+        frame->SetReturnValue(Value::NewBool(!args[0].As<SetObject>()->IsEmpty()));
     }
 
     void init_set(Interpreter* i)

--- a/src/api/stream.cc
+++ b/src/api/stream.cc
@@ -10,10 +10,7 @@ namespace tempearly
      *
      * Closes the stream. Default implementation does nothing.
      */
-    TEMPEARLY_NATIVE_METHOD(stream_close)
-    {
-        return Value::NullValue();
-    }
+    TEMPEARLY_NATIVE_METHOD(stream_close) {}
 
     /**
      * Stream#read(amount = null) => Binary or String
@@ -32,8 +29,6 @@ namespace tempearly
     TEMPEARLY_NATIVE_METHOD(stream_read)
     {
         interpreter->Throw(interpreter->eIOError, "Stream is not readable");
-
-        return Value();
     }
 
     /**
@@ -56,7 +51,7 @@ namespace tempearly
 
         if (!result)
         {
-            return Value();
+            return;
         }
         else if (result.IsBinary())
         {
@@ -68,7 +63,7 @@ namespace tempearly
                 buffer.PushBack(bytes.GetBytes(), bytes.GetLength());
                 if (!(result = receiver.Call(interpreter, "read", one)))
                 {
-                    return Value();
+                    return;
                 }
                 else if (!result.IsBinary())
                 {
@@ -80,8 +75,7 @@ namespace tempearly
             {
                 buffer.Erase(buffer.GetSize() - 1);
             }
-
-            return Value::NewBinary(ByteString(buffer.GetData(), buffer.GetSize()));
+            frame->SetReturnValue(Value::NewBinary(ByteString(buffer.GetData(), buffer.GetSize())));
         }
         else if (result.IsString())
         {
@@ -93,7 +87,7 @@ namespace tempearly
                 buffer.Append(runes);
                 if (!(result = receiver.Call(interpreter, "read", one)))
                 {
-                    return Value();
+                    return;
                 }
                 else if (!result.IsString())
                 {
@@ -105,10 +99,7 @@ namespace tempearly
             {
                 buffer.Erase(buffer.GetLength() - 1);
             }
-
-            return Value::NewString(buffer.ToString());
-        } else {
-            return Value::NullValue();
+            frame->SetReturnValue(Value::NewString(buffer.ToString()));
         }
     }
 
@@ -124,8 +115,6 @@ namespace tempearly
     TEMPEARLY_NATIVE_METHOD(stream_write)
     {
         interpreter->Throw(interpreter->eIOError, "Stream is not writable");
-
-        return Value();
     }
 
     /**
@@ -145,15 +134,13 @@ namespace tempearly
         {
             if (!args[i].ToString(interpreter, string))
             {
-                return Value();
+                return;
             }
             else if (!args[0].Call(interpreter, "write", Vector<Value>(1, Value::NewString(string))))
             {
-                return Value();
+                return;
             }
         }
-
-        return Value::NullValue();
     }
 
     namespace
@@ -205,7 +192,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(stream_iter)
     {
-        return Value(new StreamIterator(interpreter, args[0]));
+        frame->SetReturnValue(Value(new StreamIterator(interpreter, args[0])));
     }
 
     void init_stream(Interpreter* i)

--- a/src/api/string.cc
+++ b/src/api/string.cc
@@ -24,7 +24,7 @@ namespace tempearly
 
         if (size == 1 && args[0].IsString())
         {
-            return args[0];
+            frame->SetReturnValue(args[0]);
         } else {
             StringBuilder result;
             String slot;
@@ -33,12 +33,11 @@ namespace tempearly
             {
                 if (!args[i].ToString(interpreter, slot))
                 {
-                    return Value();
+                    return;
                 }
                 result << slot;
             }
-
-            return Value::NewString(result.ToString());
+            frame->SetReturnValue(Value::NewString(result.ToString()));
         }
     }
 
@@ -59,13 +58,11 @@ namespace tempearly
         {
             if (length == 0)
             {
-                interpreter->Throw(interpreter->eValueError,
-                                   "Length cannot be zero");
+                interpreter->Throw(interpreter->eValueError, "Length cannot be zero");
             }
             else if (length < 0)
             {
-                interpreter->Throw(interpreter->eValueError,
-                                   "Length cannot be less than one");
+                interpreter->Throw(interpreter->eValueError, "Length cannot be less than one");
             } else {
                 StringBuilder buffer(length);
 
@@ -73,12 +70,9 @@ namespace tempearly
                 {
                     buffer.Append(input[Random::NextU64() % 36]);
                 }
-
-                return Value::NewString(buffer.ToString());
+                frame->SetReturnValue(Value::NewString(buffer.ToString()));
             }
         }
-
-        return Value();
     }
 
     /**
@@ -90,7 +84,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(str_length)
     {
-        return Value::NewInt(args[0].AsString().GetLength());
+        frame->SetReturnValue(Value::NewInt(args[0].AsString().GetLength()));
     }
 
     /**
@@ -126,8 +120,7 @@ namespace tempearly
         {
             list->Append(Value::NewString(s.SubString(begin)));
         }
-
-        return Value(list);
+        frame->SetReturnValue(Value(list));
     }
 
     /**
@@ -147,8 +140,7 @@ namespace tempearly
         {
             list->Append(Value::NewInt(s[i]));
         }
-
-        return Value(list);
+        frame->SetReturnValue(Value(list));
     }
 
     /**
@@ -183,8 +175,7 @@ namespace tempearly
         {
             list->Append(Value::NewString(s.SubString(begin)));
         }
-
-        return Value(list);
+        frame->SetReturnValue(Value(list));
     }
 
     /**
@@ -208,11 +199,10 @@ namespace tempearly
             {
                 buffer.Append(String::ToLower(s[i]));
             }
-
-            return Value::NewString(buffer.ToString());
+            frame->SetReturnValue(Value::NewString(buffer.ToString()));
+        } else {
+            frame->SetReturnValue(args[0]);
         }
-
-        return args[0];
     }
 
     /**
@@ -235,15 +225,16 @@ namespace tempearly
 
             if (len > 1 && s[len - 2] == '\r' && s[len - 1] == '\n')
             {
-                return Value::NewString(s.SubString(0, len - 2));
+                frame->SetReturnValue(Value::NewString(s.SubString(0, len - 2)));
+                return;
             }
             else if (s[len - 1] == '\n' || s[len - 1] == '\r')
             {
-                return Value::NewString(s.SubString(0, len - 1));
+                frame->SetReturnValue(Value::NewString(s.SubString(0, len - 1)));
+                return;
             }
         }
-
-        return args[0];
+        frame->SetReturnValue(args[0]);
     }
 
     /**
@@ -260,9 +251,9 @@ namespace tempearly
 
         if (s.IsEmpty())
         {
-            return args[0];
+            frame->SetReturnValue(args[0]);
         } else {
-            return Value::NewString(s.SubString(0, s.GetLength() - 1));
+            frame->SetReturnValue(Value::NewString(s.SubString(0, s.GetLength() - 1)));
         }
     }
 
@@ -291,12 +282,11 @@ namespace tempearly
                 {
                     buffer.Append(String::ToLower(s[j]));
                 }
-
-                return Value::NewString(buffer.ToString());
+                frame->SetReturnValue(Value::NewString(buffer.ToString()));
+                return;
             }
         }
-
-        return args[0];
+        frame->SetReturnValue(args[0]);
     }
 
     /**
@@ -318,11 +308,10 @@ namespace tempearly
             {
                 buffer.Append(s[i - 1]);
             }
-
-            return Value::NewString(buffer.ToString());
+            frame->SetReturnValue(Value::NewString(buffer.ToString()));
+        } else {
+            frame->SetReturnValue(args[0]);
         }
-
-        return args[0];
     }
 
     /**
@@ -355,11 +344,10 @@ namespace tempearly
                 }
                 buffer.Append(c);
             }
-
-            return Value::NewString(buffer.ToString());
+            frame->SetReturnValue(Value::NewString(buffer.ToString()));
+        } else {
+            frame->SetReturnValue(args[0]);
         }
-
-        return args[0];
     }
 
     /**
@@ -408,11 +396,10 @@ namespace tempearly
                     buffer.Append(s.SubString(begin + 1, end - begin - 1));
                 }
             }
-
-            return Value::NewString(buffer.ToString());
+            frame->SetReturnValue(Value::NewString(buffer.ToString()));
+        } else {
+            frame->SetReturnValue(args[0]);
         }
-
-        return args[0];
     }
 
     /**
@@ -444,10 +431,10 @@ namespace tempearly
         }
         if (i != 0 || j != s.GetLength())
         {
-            return Value::NewString(s.SubString(i, j - i));
+            frame->SetReturnValue(Value::NewString(s.SubString(i, j - i)));
+        } else {
+            frame->SetReturnValue(args[0]);
         }
-
-        return args[0];
     }
 
     /**
@@ -475,12 +462,11 @@ namespace tempearly
                 {
                     buffer.Append(String::ToUpper(s[j]));
                 }
-
-                return Value::NewString(buffer.ToString());
+                frame->SetReturnValue(Value::NewString(buffer.ToString()));
+                return;
             }
         }
-
-        return args[0];
+        frame->SetReturnValue(args[0]);
     }
 
     /**
@@ -492,7 +478,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(str_hash)
     {
-        return Value::NewInt(args[0].AsString().HashCode());
+        frame->SetReturnValue(Value::NewInt(args[0].AsString().HashCode()));
     }
 
     namespace
@@ -540,8 +526,7 @@ namespace tempearly
         } else {
             iterator = new StringIterator(interpreter->cIterator, s);
         }
-
-        return Value(iterator);
+        frame->SetReturnValue(Value(iterator));
     }
 
     /**
@@ -552,7 +537,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(str_bool)
     {
-        return Value::NewBool(!args[0].AsString().IsEmpty());
+        frame->SetReturnValue(Value::NewBool(!args[0].AsString().IsEmpty()));
     }
 
     /**
@@ -565,8 +550,7 @@ namespace tempearly
         StringBuilder buffer;
 
         buffer << '"' << args[0].AsString().EscapeJavaScript() << '"';
-
-        return Value::NewString(buffer.ToString());
+        frame->SetReturnValue(Value::NewString(buffer.ToString()));
     }
 
     /**
@@ -589,18 +573,17 @@ namespace tempearly
 
             if (a.IsEmpty())
             {
-                return operand;
+                frame->SetReturnValue(operand);
             }
             else if (b.IsEmpty())
             {
-                return args[0];
+                frame->SetReturnValue(args[0]);
             } else {
-                return Value::NewString(a + b);
+                frame->SetReturnValue(Value::NewString(a + b));
             }
+        } else {
+            interpreter->Throw(interpreter->eValueError, "String value required");
         }
-        interpreter->Throw(interpreter->eValueError, "String value required");
-
-        return Value();
     }
 
     /**
@@ -622,12 +605,11 @@ namespace tempearly
 
             if (count < 0)
             {
-                interpreter->Throw(interpreter->eValueError,
-                                   "Negative multiplier");
+                interpreter->Throw(interpreter->eValueError, "Negative multiplier");
             }
             else if (count == 1 || string.IsEmpty())
             {
-                return args[0];
+                frame->SetReturnValue(args[0]);
             } else {
                 StringBuilder buffer(string.GetLength() * count);
 
@@ -635,12 +617,9 @@ namespace tempearly
                 {
                     buffer.Append(string);
                 }
-
-                return Value::NewString(buffer.ToString());
+                frame->SetReturnValue(Value::NewString(buffer.ToString()));
             }
         }
-
-        return Value();
     }
 
     /**
@@ -654,12 +633,11 @@ namespace tempearly
         const Value& self = args[0];
         const Value& operand = args[1];
 
-        if (operand.IsString())
-        {
-            return Value::NewBool(self.AsString().Equals(operand.AsString()));
-        } else {
-            return Value::NewBool(false);
-        }
+        frame->SetReturnValue(
+            Value::NewBool(
+                operand.IsString() ? self.AsString().Equals(operand.AsString()) : false
+            )
+        );
     }
 
     /**
@@ -678,14 +656,13 @@ namespace tempearly
 
         if (operand.IsString())
         {
-            return Value::NewBool(self.AsString().Compare(operand.AsString()) < 0);
+            frame->SetReturnValue(Value::NewBool(self.AsString().Compare(operand.AsString()) < 0));
+        } else {
+            interpreter->Throw(
+                interpreter->eTypeError,
+                "Cannot compare '" + operand.GetClass(interpreter)->GetName() + "' with 'String'"
+            );
         }
-        interpreter->Throw(
-            interpreter->eTypeError,
-            "Cannot compare '" + operand.GetClass(interpreter)->GetName() + "' with 'String'"
-        );
-
-        return Value();
     }
 
     /**
@@ -704,14 +681,12 @@ namespace tempearly
 
         if (parser->ParseValue(interpreter, value))
         {
-            return value;
+            frame->SetReturnValue(value);
         }
         else if (!interpreter->HasException())
         {
             interpreter->Throw(interpreter->eValueError, parser->GetErrorMessage());
         }
-
-        return Value();
     }
 
     void init_string(Interpreter* i)

--- a/src/api/void.cc
+++ b/src/api/void.cc
@@ -10,7 +10,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(void_iter)
     {
-        return Value(interpreter->GetEmptyIterator());
+        frame->SetReturnValue(Value(interpreter->GetEmptyIterator()));
     }
 
     /**
@@ -20,7 +20,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(void_str)
     {
-        return Value::NewString(String());
+        frame->SetReturnValue(Value::NewString(String()));
     }
 
     /**
@@ -30,7 +30,7 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(void_as_json)
     {
-        return Value::NewString("null");
+        frame->SetReturnValue(Value::NewString("null"));
     }
 
     void init_void(Interpreter* i)

--- a/src/frame.cc
+++ b/src/frame.cc
@@ -106,5 +106,6 @@ namespace tempearly
                 e->GetValue().Mark();
             }
         }
+        m_return_value.Mark();
     }
 }

--- a/src/frame.h
+++ b/src/frame.h
@@ -107,6 +107,31 @@ namespace tempearly
          */
         bool ReplaceLocalVariable(const String& id, const Value& value);
 
+        /**
+         * Returns true if this frame has a return value.
+         */
+        inline bool HasReturnValue() const
+        {
+            return m_return_value;
+        }
+
+        /**
+         * Returns value returned by the function invocation or error value if
+         * no value was returned.
+         */
+        inline const Value& GetReturnValue() const
+        {
+            return m_return_value;
+        }
+
+        /**
+         * Sets value returned by the function invocation.
+         */
+        inline void SetReturnValue(const Value& return_value)
+        {
+            m_return_value = return_value;
+        }
+
         void Mark();
 
     private:
@@ -118,6 +143,8 @@ namespace tempearly
         FunctionObject* m_function;
         /** Container for local variables. */
         Dictionary<Value>* m_local_variables;
+        /** Value returned by the function. */
+        Value m_return_value;
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(Frame);
     };
 }

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -25,7 +25,8 @@ namespace tempearly
 
         void AddFunction(const String& name,
                          int arity,
-                         Value(*callback)(const Handle<Interpreter>&,
+                         void (*callback)(const Handle<Interpreter>&,
+                                          const Handle<Frame>&,
                                           const Vector<Value>&));
 
         /**
@@ -42,9 +43,10 @@ namespace tempearly
          *
          * \param enclosing Optional handle of enclosing frame
          * \param function  Optional handle of function being executed
+         * \return          Newly created stack frame
          */
-        void PushFrame(const Handle<Frame>& enclosing = Handle<Frame>(),
-                       const Handle<FunctionObject>& function = Handle<FunctionObject>());
+        Handle<Frame> PushFrame(const Handle<Frame>& enclosing = Handle<Frame>(),
+                                const Handle<FunctionObject>& function = Handle<FunctionObject>());
 
         /**
          * Pops the most recent stack frame from frame chain.

--- a/src/macros.h
+++ b/src/macros.h
@@ -18,7 +18,8 @@
 #endif
 
 #define TEMPEARLY_NATIVE_METHOD(MethodName) \
-    static Value MethodName(const Handle<Interpreter>& interpreter, \
-                            const Vector<Value>& args)
+    static void MethodName(const Handle<Interpreter>& interpreter, \
+                           const Handle<Frame>& frame, \
+                           const Vector<Value>& args)
 
 #endif /* !TEMPEARLY_MACROS_H_GUARD */


### PR DESCRIPTION
1. Modify way how native functions work in the C++ API by changing the
   return type to `void` and adding additional argument `frame` which is
   the stack frame of currently executed function.
   
   The `Frame` class now contains the value returned by the function. It
   can be set with `SetReturnValue` method. This way GC can find and
   mark values returned by function calls, which hopefully reduces GC
   related bugs.
2. Also modify `FunctionObject` so that the `Invoke` method returns
   `bool` and accepts a `Slot` value as argument where value returned by
   function call will be assigned to.
