### PR TITLE
List API additions.

### DIFF
--- a/src/api/list.cc
+++ b/src/api/list.cc
@@ -1,6 +1,7 @@
 #include "interpreter.h"
 #include "api/iterator.h"
 #include "api/list.h"
+#include "api/range.h"
 
 namespace tempearly
 {
@@ -10,11 +11,24 @@ namespace tempearly
         , m_front(0)
         , m_back(0) {}
 
+    Handle<ListObject::Link> ListObject::At(std::size_t index) const
+    {
+        for (Handle<Link> link = m_front; link; link = link->m_next)
+        {
+            if (!index--)
+            {
+                return link;
+            }
+        }
+
+        return Handle<Link>();
+    }
+
     void ListObject::Append(const Value& value)
     {
         Handle<Link> link = new Link(value);
 
-        if (m_back)
+        if ((link->m_prev = m_back))
         {
             m_back->m_next = link;
         } else {
@@ -35,6 +49,7 @@ namespace tempearly
             {
                 Handle<Link> link = new Link(vector[i]);
 
+                link->m_prev = back;
                 back->m_next = link;
                 back = link;
             }
@@ -59,7 +74,7 @@ namespace tempearly
         {
             Handle<Link> b = new Link(a->m_value);
 
-            if (m_back)
+            if ((b->m_prev = m_back))
             {
                 m_back->m_next = b;
             } else {
@@ -74,8 +89,10 @@ namespace tempearly
     {
         Handle<Link> link = new Link(value);
 
-        if (!(link->m_next = m_front))
+        if ((link->m_next = m_front))
         {
+            m_front->m_prev = link;
+        } else {
             m_back = link;
         }
         m_front = link;
@@ -93,6 +110,7 @@ namespace tempearly
             {
                 Handle<Link> link = new Link(vector[i]);
 
+                link->m_prev = back;
                 back->m_next = link;
                 back = link;
             }
@@ -105,6 +123,87 @@ namespace tempearly
             m_front = front;
             m_size += vector.GetSize();
         }
+    }
+
+    void ListObject::Insert(std::size_t index, const Value& value)
+    {
+        Handle<Link> position = At(index);
+
+        if (position)
+        {
+            Handle<Link> link = new Link(value);
+
+            link->m_prev = position;
+            if (position->m_next)
+            {
+                position->m_next->m_prev = link;
+            } else {
+                m_back = link;
+            }
+            position->m_next = link;
+            ++m_size;
+        } else {
+            Append(value);
+        }
+    }
+
+    void ListObject::Erase(std::size_t index)
+    {
+        Handle<Link> link = At(index);
+
+        if (!link)
+        {
+            return;
+        }
+        if (link->m_next && link->m_prev)
+        {
+            link->m_next->m_prev = link->m_prev;
+            link->m_prev->m_next = link->m_next;
+        }
+        else if (link->m_next)
+        {
+            link->m_next->m_prev = 0;
+            m_front = link->m_next;
+        }
+        else if (link->m_prev)
+        {
+            link->m_prev->m_next = 0;
+            m_back = link->m_prev;
+        } else {
+            m_front = m_back = 0;
+        }
+        --m_size;
+    }
+
+    bool ListObject::Erase(std::size_t index, Value& slot)
+    {
+        Handle<Link> link = At(index);
+
+        if (!link)
+        {
+            return false;
+        }
+        if (link->m_next && link->m_prev)
+        {
+            link->m_next->m_prev = link->m_prev;
+            link->m_prev->m_next = link->m_next;
+        }
+        else if (link->m_next)
+        {
+            link->m_next->m_prev = 0;
+            m_front = link->m_next;
+        }
+        else if (link->m_prev)
+        {
+            link->m_prev->m_next = 0;
+            m_back = link->m_prev;
+        } else {
+            m_front = m_back = 0;
+        }
+        --m_size;
+        slot = link->m_value;
+
+        return true;
     }
 
     void ListObject::Clear()
@@ -124,7 +223,8 @@ namespace tempearly
 
     ListObject::Link::Link(const Value& value)
         : m_value(value)
-        , m_next(0) {}
+        , m_next(0)
+        , m_prev(0) {}
 
     void ListObject::Link::Mark()
     {
@@ -133,6 +233,10 @@ namespace tempearly
         if (m_next && !m_next->IsMarked())
         {
             m_next->Mark();
+        }
+        if (m_prev && !m_prev->IsMarked())
+        {
+            m_prev->Mark();
         }
     }
 
@@ -204,6 +308,27 @@ namespace tempearly
     }
 
     /**
+     * List#insert(index, object)
+     *
+     * Inserts an value at given position.
+     */
+    TEMPEARLY_NATIVE_METHOD(list_insert)
+    {
+        Handle<ListObject> list = args[0].As<ListObject>();
+        i64 index;
+
+        if (!args[1].AsInt(interpreter, index))
+        {
+            return;
+        }
+        if (index < 0)
+        {
+            index += list->GetSize();
+        }
+        list->Insert(static_cast<std::size_t>(index), args[2]);
+    }
+
+    /**
      * List#clear()
      *
      * Removes all elements from the list.
@@ -212,6 +337,110 @@ namespace tempearly
     {
         args[0].As<ListObject>()->Clear();
         frame->SetReturnValue(args[0]);
+    }
+
+    /**
+     * List#index(object) => Int
+     *
+     * Returns index of element from the list which value is equal to value
+     * given as argument. If no element is found, an ValueError is thrown
+     * instead.
+     */
+    TEMPEARLY_NATIVE_METHOD(list_index)
+    {
+        const Value& needle = args[1];
+        bool result;
+        i64 index = 0;
+
+        for (Handle<ListObject::Link> link = args[0].As<ListObject>()->GetFront(); link; link = link->GetNext())
+        {
+            if (!link->GetValue().Equals(interpreter, needle, result))
+            {
+                return;
+            }
+            else if (result)
+            {
+                frame->SetReturnValue(Value::NewInt(index));
+                return;
+            }
+            ++index;
+        }
+        interpreter->Throw(interpreter->eValueError, "Value is not in the list");
+    }
+
+    /**
+     * List#remove(object)
+     *
+     * Removes the first element from the list which value is equal to value
+     * given as argument. If no element is found, an ValueError is thrown
+     * instead.
+     */
+    TEMPEARLY_NATIVE_METHOD(list_remove)
+    {
+        Handle<ListObject> list = args[0].As<ListObject>();
+        const Value& needle = args[1];
+        bool result;
+        std::size_t index = 0;
+
+        for (Handle<ListObject::Link> link = list->GetFront(); link; link = link->GetNext())
+        {
+            if (!link->GetValue().Equals(interpreter, needle, result))
+            {
+                return;
+            }
+            else if (result)
+            {
+                list->Erase(index);
+                return;
+            }
+            ++index;
+        }
+        interpreter->Throw(interpreter->eValueError, "Value is not in the list");
+    }
+
+    /**
+     * List#pop(index) => Object
+     *
+     * Removes element from given position in the list, and returns it's value.
+     * If no index is specified, the last element from the list is removed and
+     * it's value is returned.
+     *
+     * If index is out of bounds, IndexError is thrown instead.
+     */
+    TEMPEARLY_NATIVE_METHOD(list_pop)
+    {
+        Handle<ListObject> list = args[0].As<ListObject>();
+        Value value;
+
+        if (args.GetSize() > 1)
+        {
+            i64 index;
+
+            if (!args[1].AsInt(interpreter, index))
+            {
+                return;
+            }
+            if (index < 0)
+            {
+                index += list->GetSize();
+            }
+            if (!list->Erase(static_cast<std::size_t>(index), value))
+            {
+                interpreter->Throw(interpreter->eIndexError, "List index out of bounds");
+                return;
+            }
+        } else {
+            Handle<ListObject::Link> link = list->GetBack();
+
+            if (!link)
+            {
+                interpreter->Throw(interpreter->eIndexError, "List is empty");
+                return;
+            }
+            value = link->GetValue();
+            list->Erase(list->GetSize() - 1);
+        }
+        frame->SetReturnValue(value);
     }
 
     namespace
@@ -306,6 +535,31 @@ namespace tempearly
     }
 
     /**
+     * List#__mul__(n) => List
+     *
+     * Repeats list n times.
+     *
+     *     [1, 2] * 3;  #=> [1, 2, 1, 2, 1, 2]
+     */
+    TEMPEARLY_NATIVE_METHOD(list_mul)
+    {
+        Handle<ListObject> original = args[0].As<ListObject>();
+        Handle<ListObject> result;
+        i64 n;
+
+        if (!args[1].AsInt(interpreter, n))
+        {
+            return;
+        }
+        result = new ListObject(interpreter->cList);
+        while (n-- > 0)
+        {
+            result->Append(original);
+        }
+        frame->SetReturnValue(Value(result));
+    }
+
+    /**
      * List#__bool__() => Bool
      *
      * Boolean representation of list. Non-empty lists evaluate as true.
@@ -313,6 +567,104 @@ namespace tempearly
     TEMPEARLY_NATIVE_METHOD(list_bool)
     {
         frame->SetReturnValue(Value::NewBool(!args[0].As<ListObject>()->IsEmpty()));
+    }
+
+    /**
+     * List#__getitem__(index) => Object
+     *
+     * List element retrieval. Two types of indexes are supported.
+     *
+     * If an number is given as an index, an element from that specified index
+     * is returned. If index is out of bounds, an IndexError is thrown instead.
+     *
+     * If a range object is given as an index, it's beginning and ending values
+     * are used as slice indexes which slice a portion of the list and returns
+     * it as a new list.
+     *
+     * Negative indexes count backwards, for example -1 is index of the last
+     * element in the list.
+     */
+    TEMPEARLY_NATIVE_METHOD(list_getitem)
+    {
+        Handle<ListObject> list = args[0].As<ListObject>();
+        Handle<ListObject::Link> link;
+
+        if (args[1].IsRange())
+        {
+            Handle<ListObject> result;
+            Handle<RangeObject> range = args[1].As<RangeObject>();
+            i64 begin;
+            i64 end;
+
+            if (!range->GetBegin().AsInt(interpreter, begin) || !range->GetEnd().AsInt(interpreter, end))
+            {
+                return;
+            }
+            if (range->IsExclusive())
+            {
+                --end;
+            }
+            if (begin < 0)
+            {
+                begin += list->GetSize();
+            }
+            if (end < 0)
+            {
+                end += list->GetSize();
+            }
+            result = new ListObject(interpreter->cList);
+            for (link = list->At(begin); link && begin < end; link = link->GetNext(), ++begin)
+            {
+                result->Append(link->GetValue());
+            }
+            frame->SetReturnValue(Value(result));
+        } else {
+            i64 index;
+
+            if (!args[1].AsInt(interpreter, index))
+            {
+                return;
+            }
+            if (index < 0)
+            {
+                index += list->GetSize();
+            }
+            if ((link = list->At(static_cast<std::size_t>(index))))
+            {
+                frame->SetReturnValue(link->GetValue());
+            } else {
+                interpreter->Throw(interpreter->eIndexError, "List index out of bounds");
+            }
+        }
+    }
+
+    /**
+     * List#__setitem__(index, object)
+     *
+     * Element assignment. Replaces value from given index with given object.
+     * Negative indexes count backwards. If index is out of bounds, IndexError
+     * is thrown instead.
+     */
+    TEMPEARLY_NATIVE_METHOD(list_setitem)
+    {
+        Handle<ListObject> list = args[0].As<ListObject>();
+        Handle<ListObject::Link> link;
+        i64 index;
+
+        if (!args[1].AsInt(interpreter, index))
+        {
+            return;
+        }
+        if (index < 0)
+        {
+            index += list->GetSize();
+        }
+        if ((link = list->At(static_cast<std::size_t>(index))))
+        {
+            link->SetValue(args[2]);
+        } else {
+            interpreter->Throw(interpreter->eIndexError, "List index out of bounds");
+        }
     }
 
     void init_list(Interpreter* i)
@@ -327,15 +679,23 @@ namespace tempearly
 
         i->cList->AddMethod(i, "append", -1, list_append);
         i->cList->AddMethod(i, "prepend", -1, list_prepend);
+        i->cList->AddMethod(i, "insert", 2, list_insert);
         i->cList->AddMethod(i, "clear", 0, list_clear);
+        i->cList->AddMethod(i, "index", 1, list_index);
+        i->cList->AddMethod(i, "remove", 1, list_remove);
+        i->cList->AddMethod(i, "pop", -1, list_pop);
 
         i->cList->AddMethod(i, "__iter__", 0, list_iter);
 
         // Operators
         i->cList->AddMethod(i, "__add__", 1, list_add);
+        i->cList->AddMethod(i, "__mul__", 1, list_mul);
 
         // Conversion methods
         i->cList->AddMethod(i, "__bool__", 0, list_bool);
         i->cList->AddMethodAlias(i, "__str__", "join");
+
+        i->cList->AddMethod(i, "__getitem__", 1, list_getitem);
+        i->cList->AddMethod(i, "__setitem__", 2, list_setitem);
     }
 }

--- a/src/api/list.h
+++ b/src/api/list.h
@@ -50,6 +50,14 @@ namespace tempearly
             }
 
             /**
+             * Returns pointer to previous link in the list.
+             */
+            inline Handle<Link> GetPrevious() const
+            {
+                return m_prev;
+            }
+
+            /**
              * Used by garbage collector to mark the object as used.
              */
             void Mark();
@@ -59,6 +67,8 @@ namespace tempearly
             Value m_value;
             /** Pointer to next entry in the list. */
             Link* m_next;
+            /** Pointer to previous entry in the list. */
+            Link* m_prev;
             friend class ListObject;
             TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(Link);
         };
@@ -105,6 +115,12 @@ namespace tempearly
         }
 
         /**
+         * Returns an link from specified index or null handle if the index is
+         * out of bounds.
+         */
+        Handle<Link> At(std::size_t index) const;
+
+        /**
          * Inserts given value into the list.
          */
         void Append(const Value& value);
@@ -128,6 +144,29 @@ namespace tempearly
          * Inserts all elements from given vector into beginning of the list.
          */
         void Prepend(const Vector<Value>& vector);
+
+        /**
+         * Inserts an element at the given position. If position is out of
+         * bounds, the element will be appended at the end of the list.
+         */
+        void Insert(std::size_t index, const Value& value);
+
+        /**
+         * Removes an value from the specified index.
+         *
+         * \param index Index of the element to remove
+         */
+        void Erase(std::size_t index);
+
+        /**
+         * Removes an value from the specified index.
+         *
+         * \param index Index of the element to remove
+         * \param slot  Where value of the element is assigned to
+         * \return      A boolean flag indicating whether element with given
+         *              index was found or not
+         */
+        bool Erase(std::size_t index, Value& slot);
 
         /**
          * Removes all values from the list.


### PR DESCRIPTION
Similiar as in previous pull request #99 added missing methods to `Map`
class, this commit adds some missing methods to `List` class. These
include searching for list elements, removing them and subscript
operators `__getitem__` and `__setitem__`. Also modifies
`ListObject::Link` class so that it contains pointer to previous list
node as well as pointer to next list node.
