### PR TITLE
Temporary fix to POST parsing problem.

### DIFF
--- a/src/core/string.cc
+++ b/src/core/string.cc
@@ -744,6 +744,39 @@ namespace tempearly
         }
     }
 
+    bool String::StartsWith(const String& that) const
+    {
+        if (!that.m_length)
+        {
+            return true;
+        }
+        else if (!m_length)
+        {
+            return false;
+        }
+        else if (that.m_length == 1)
+        {
+            return m_runes[m_offset + m_length - 1] == that.m_runes[that.m_offset];
+        }
+        else if (that.m_length > m_length)
+        {
+            return false;
+        }
+        else if (that.m_length == m_length)
+        {
+            return Equals(that);
+        }
+        for (std::size_t i = 0; i < that.m_length; ++i)
+        {
+            if (m_runes[m_offset + i] != that.m_runes[that.m_offset + i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     void String::Clear()
     {
         if (m_counter && --m_counter[0] == 0)

--- a/src/core/string.h
+++ b/src/core/string.h
@@ -306,6 +306,11 @@ namespace tempearly
         }
 
         /**
+         * Returns true if this strings starts with given substring.
+         */
+        bool StartsWith(const String& that) const;
+
+        /**
          * Clears all contents of the string.
          */
         void Clear();

--- a/src/sapi/request.cc
+++ b/src/sapi/request.cc
@@ -95,7 +95,7 @@ namespace tempearly
         // TODO: process multipart requests
         if (GetMethod() == HttpMethod::POST
             && GetContentLength() > 0
-            && GetContentType() == "application/x-www-form-urlencoded")
+            && GetContentType().StartsWith("application/x-www-form-urlencoded"))
         {
             const ByteString body = GetBody();
 


### PR DESCRIPTION
This is *ugly*, non-optimal workaround to problem where POST data is not
parsed because character encoding is included in the MIME type (such as
`application/x-www-form-urlencoded; charset=UTF-8`).

It should be only temporary fix, we need to eventually implement
decoding and encoding various character encodings and add a real MIME
type parser.