### PR TITLE
Add support for `else` statement in `for` statement.

### DIFF
--- a/src/script/node.h
+++ b/src/script/node.h
@@ -167,7 +167,8 @@ namespace tempearly
     public:
         explicit ForNode(const Handle<Node>& variable,
                          const Handle<Node>& collection,
-                         const Handle<Node>& statement);
+                         const Handle<Node>& statement,
+                         const Handle<Node>& else_statement = Handle<Node>());
 
         Result Execute(const Handle<Interpreter>& interpreter) const;
 
@@ -177,6 +178,7 @@ namespace tempearly
         Node* m_variable;
         Node* m_collection;
         Node* m_statement;
+        Node* m_else_statement;
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(ForNode);
     };
 

--- a/src/script/parser.cc
+++ b/src/script/parser.cc
@@ -1095,6 +1095,7 @@ SCAN_EXPONENT:
         Handle<Node> variable;
         Handle<Node> collection;
         Handle<Node> statement;
+        Handle<Node> else_statement;
 
         if (!expect_token(parser, Token::KW_FOR) || !(variable = parse_expr(parser)))
         {
@@ -1109,15 +1110,27 @@ SCAN_EXPONENT:
         if (!expect_token(parser, Token::COLON)
             || !(collection = parse_expr(parser))
             || !expect_token(parser, Token::COLON)
-            || !(statement = parse_block(parser))
-            || !expect_token(parser, Token::KW_END)
-            || !expect_token(parser, Token::KW_FOR))
+            || !(statement = parse_block(parser)))
+        {
+            return Handle<Node>();
+        }
+        if (parser->ReadToken(Token::KW_ELSE))
+        {
+            if (!expect_token(parser, Token::COLON)
+                || !(else_statement = parse_block(parser))
+                || !expect_token(parser, Token::KW_END)
+                || !expect_token(parser, Token::KW_FOR))
+            {
+                return Handle<Node>();
+            }
+        }
+        else if (!expect_token(parser, Token::KW_END) || !expect_token(parser, Token::KW_FOR))
         {
             return Handle<Node>();
         }
         parser->ReadToken(Token::SEMICOLON); // Eat optional semicolon
 
-        return new ForNode(variable, collection, statement);
+        return new ForNode(variable, collection, statement, else_statement);
     }
 
     static Handle<CatchNode> parse_catch(const Handle<ScriptParser>& parser)


### PR DESCRIPTION
This implements an idea I saw used in Jinja template engine: For loop
which iterates over collections may have an `else` statement which
executed only when the collection is empty. I think it's super handy
dandy and should be included also in Tempearly.

Example of usage:

    for element : some_collection:
        print(element);
    else:
        print("The collection is empty.");
    end for;