### PR TITLE
C++11: Use nullptr everywhere.

### DIFF
--- a/src/api/class.cc
+++ b/src/api/class.cc
@@ -10,7 +10,7 @@ namespace tempearly
     Class::Class(const Handle<Class>& base)
         : m_base(base.Get())
         , m_allocator(m_base ? m_base->m_allocator : 0)
-        , m_attributes(0) {}
+        , m_attributes(nullptr) {}
 
     Class::~Class()
     {

--- a/src/api/list.cc
+++ b/src/api/list.cc
@@ -8,8 +8,8 @@ namespace tempearly
     ListObject::ListObject(const Handle<Class>& cls)
         : Object(cls)
         , m_size(0)
-        , m_front(0)
-        , m_back(0) {}
+        , m_front(nullptr)
+        , m_back(nullptr) {}
 
     Handle<ListObject::Link> ListObject::At(std::size_t index) const
     {
@@ -162,15 +162,15 @@ namespace tempearly
         }
         else if (link->m_next)
         {
-            link->m_next->m_prev = 0;
+            link->m_next->m_prev = nullptr;
             m_front = link->m_next;
         }
         else if (link->m_prev)
         {
-            link->m_prev->m_next = 0;
+            link->m_prev->m_next = nullptr;
             m_back = link->m_prev;
         } else {
-            m_front = m_back = 0;
+            m_front = m_back = nullptr;
         }
         --m_size;
     }
@@ -190,15 +190,15 @@ namespace tempearly
         }
         else if (link->m_next)
         {
-            link->m_next->m_prev = 0;
+            link->m_next->m_prev = nullptr;
             m_front = link->m_next;
         }
         else if (link->m_prev)
         {
-            link->m_prev->m_next = 0;
+            link->m_prev->m_next = nullptr;
             m_back = link->m_prev;
         } else {
-            m_front = m_back = 0;
+            m_front = m_back = nullptr;
         }
         --m_size;
         slot = link->m_value;
@@ -208,7 +208,7 @@ namespace tempearly
 
     void ListObject::Clear()
     {
-        m_front = m_back = 0;
+        m_front = m_back = nullptr;
         m_size = 0;
     }
 
@@ -223,8 +223,8 @@ namespace tempearly
 
     ListObject::Link::Link(const Value& value)
         : m_value(value)
-        , m_next(0)
-        , m_prev(0) {}
+        , m_next(nullptr)
+        , m_prev(nullptr) {}
 
     void ListObject::Link::Mark()
     {

--- a/src/api/map.cc
+++ b/src/api/map.cc
@@ -10,20 +10,20 @@ namespace tempearly
     MapObject::MapObject(const Handle<Class>& cls, std::size_t bucket_size)
         : Object(cls)
         , m_bucket_size(bucket_size)
-        , m_bucket(new Entry*[m_bucket_size])
-        , m_front(0)
-        , m_back(0)
+        , m_bucket(Memory::Allocate<Entry*>(m_bucket_size))
+        , m_front(nullptr)
+        , m_back(nullptr)
         , m_size(0)
     {
         for (std::size_t i = 0; i < m_bucket_size; ++i)
         {
-            m_bucket[i] = 0;
+            m_bucket[i] = nullptr;
         }
     }
 
     MapObject::~MapObject()
     {
-        delete[] m_bucket;
+        Memory::Unallocate<Entry*>(m_bucket);
     }
 
     bool MapObject::Has(i64 hash) const
@@ -104,15 +104,15 @@ namespace tempearly
             }
             else if (entry->m_next)
             {
-                entry->m_next->m_prev = 0;
+                entry->m_next->m_prev = nullptr;
                 m_front = entry->m_next;
             }
             else if (entry->m_prev)
             {
-                entry->m_prev->m_next = 0;
+                entry->m_prev->m_next = nullptr;
                 m_back = entry->m_prev;
             } else {
-                m_front = m_back = 0;
+                m_front = m_back = nullptr;
             }
             slot = entry->m_value;
 
@@ -132,15 +132,15 @@ namespace tempearly
                 }
                 else if (child->m_next)
                 {
-                    child->m_next->m_prev = 0;
+                    child->m_next->m_prev = nullptr;
                     m_front = child->m_next;
                 }
                 else if (child->m_prev)
                 {
-                    child->m_prev->m_next = 0;
+                    child->m_prev->m_next = nullptr;
                     m_back = child->m_prev;
                 } else {
-                    m_front = m_back = 0;
+                    m_front = m_back = nullptr;
                 }
                 slot = child->m_value;
 
@@ -155,9 +155,9 @@ namespace tempearly
     {
         for (std::size_t i = 0; i < m_bucket_size; ++i)
         {
-            m_bucket[i] = 0;
+            m_bucket[i] = nullptr;
         }
-        m_front = m_back = 0;
+        m_front = m_back = nullptr;
         m_size = 0;
     }
 
@@ -174,9 +174,9 @@ namespace tempearly
         : m_hash(hash)
         , m_key(key)
         , m_value(value)
-        , m_next(0)
-        , m_prev(0)
-        , m_child(0) {}
+        , m_next(nullptr)
+        , m_prev(nullptr)
+        , m_child(nullptr) {}
 
     void MapObject::Entry::Mark()
     {

--- a/src/api/object.cc
+++ b/src/api/object.cc
@@ -7,7 +7,7 @@ namespace tempearly
 {
     Object::Object(const Handle<Class>& cls)
         : m_class(cls.Get())
-        , m_attributes(0) {}
+        , m_attributes(nullptr) {}
 
     Object::~Object()
     {

--- a/src/api/set.cc
+++ b/src/api/set.cc
@@ -7,20 +7,20 @@ namespace tempearly
     SetObject::SetObject(const Handle<Class>& cls, std::size_t bucket_size)
         : Object(cls)
         , m_bucket_size(bucket_size)
-        , m_bucket(new Entry*[m_bucket_size])
+        , m_bucket(Memory::Allocate<Entry*>(m_bucket_size))
         , m_size(0)
-        , m_front(0)
-        , m_back(0)
+        , m_front(nullptr)
+        , m_back(nullptr)
     {
         for (std::size_t i = 0; i < m_bucket_size; ++i)
         {
-            m_bucket[i] = 0;
+            m_bucket[i] = nullptr;
         }
     }
 
     SetObject::~SetObject()
     {
-        delete[] m_bucket;
+        Memory::Unallocate<Entry*>(m_bucket);
     }
 
     bool SetObject::Has(i64 hash) const
@@ -121,15 +121,15 @@ namespace tempearly
             }
             else if (entry->m_next)
             {
-                entry->m_next->m_prev = 0;
+                entry->m_next->m_prev = nullptr;
                 m_front = entry->m_next;
             }
             else if (entry->m_prev)
             {
-                entry->m_prev->m_next = 0;
+                entry->m_prev->m_next = nullptr;
                 m_back = entry->m_prev;
             } else {
-                m_front = m_back = 0;
+                m_front = m_back = nullptr;
             }
             --m_size;
 
@@ -149,15 +149,15 @@ namespace tempearly
                 }
                 else if (child->m_next)
                 {
-                    child->m_next->m_prev = 0;
+                    child->m_next->m_prev = nullptr;
                     m_front = child->m_next;
                 }
                 else if (child->m_prev)
                 {
-                    child->m_prev->m_next = 0;
+                    child->m_prev->m_next = nullptr;
                     m_back = child->m_prev;
                 } else {
-                    m_front = m_back = 0;
+                    m_front = m_back = nullptr;
                 }
                 --m_size;
 
@@ -172,9 +172,9 @@ namespace tempearly
     {
         for (std::size_t i = 0; i < m_bucket_size; ++i)
         {
-            m_bucket[i] = 0;
+            m_bucket[i] = nullptr;
         }
-        m_front = m_back = 0;
+        m_front = m_back = nullptr;
         m_size = 0;
     }
 
@@ -190,9 +190,9 @@ namespace tempearly
     SetObject::Entry::Entry(i64 hash, const Value& value)
         : m_hash(hash)
         , m_value(value)
-        , m_next(0)
-        , m_prev(0)
-        , m_child(0) {}
+        , m_next(nullptr)
+        , m_prev(nullptr)
+        , m_child(nullptr) {}
 
     void SetObject::Entry::Mark()
     {

--- a/src/core/dictionary.h
+++ b/src/core/dictionary.h
@@ -74,9 +74,9 @@ namespace tempearly
                 : m_hash_code(hash_code)
                 , m_name(name)
                 , m_value(value)
-                , m_next(0)
-                , m_previous(0)
-                , m_child(0) {}
+                , m_next(nullptr)
+                , m_previous(nullptr)
+                , m_child(nullptr) {}
 
             /** Cached hash code of the entry. */
             std::size_t m_hash_code;
@@ -99,12 +99,12 @@ namespace tempearly
          */
         Dictionary()
             : m_bucket(Memory::Allocate<Entry*>(kBucketSize))
-            , m_front(0)
-            , m_back(0)
+            , m_front(nullptr)
+            , m_back(nullptr)
         {
             for (std::size_t i = 0; i < kBucketSize; ++i)
             {
-                m_bucket[i] = 0;
+                m_bucket[i] = nullptr;
             }
         }
 
@@ -114,19 +114,19 @@ namespace tempearly
          */
         Dictionary(const Dictionary<T>& that)
             : m_bucket(Memory::Allocate<Entry*>(kBucketSize))
-            , m_front(0)
-            , m_back(0)
+            , m_front(nullptr)
+            , m_back(nullptr)
         {
             for (std::size_t i = 0; i < kBucketSize; ++i)
             {
-                m_bucket[i] = 0;
+                m_bucket[i] = nullptr;
             }
             for (const Entry* entry1 = that.m_front; entry1; entry1 = entry1->m_next)
             {
                 Entry* entry2 = new Entry(entry1->m_hash_code, entry1->m_name, entry1->m_value);
                 const std::size_t index = entry1->m_hash_code % kBucketSize;
 
-                entry2->m_next = 0;
+                entry2->m_next = nullptr;
                 if ((entry2->m_previous = m_back))
                 {
                     m_back->m_next = entry2;
@@ -146,12 +146,12 @@ namespace tempearly
         template< class U >
         Dictionary(const Dictionary<U>& that)
             : m_bucket(Memory::Allocate<Entry*>(kBucketSize))
-            , m_front(0)
-            , m_back(0)
+            , m_front(nullptr)
+            , m_back(nullptr)
         {
             for (std::size_t i = 0; i < kBucketSize; ++i)
             {
-                m_bucket[i] = 0;
+                m_bucket[i] = nullptr;
             }
             for (const typename Dictionary<U>::Entry* entry1 = that.GetFront();
                  entry1;
@@ -160,7 +160,7 @@ namespace tempearly
                 Entry* entry2 = new Entry(entry1->m_hash_code, entry1->m_name, entry1->m_value);
                 const std::size_t index = entry1->m_hash_code % kBucketSize;
 
-                entry2->m_next = 0;
+                entry2->m_next = nullptr;
                 if ((entry2->m_previous = m_back))
                 {
                     m_back->m_next = entry2;
@@ -201,7 +201,7 @@ namespace tempearly
                 Entry* entry2 = new Entry(entry1->m_hash_code, entry1->m_name, entry1->m_value);
                 const std::size_t index = entry1->m_hash_code % kBucketSize;
 
-                entry2->m_next = 0;
+                entry2->m_next = nullptr;
                 if ((entry2->m_previous = m_back))
                 {
                     m_back->m_next = entry2;
@@ -230,7 +230,7 @@ namespace tempearly
                 Entry* entry2 = new Entry(entry1->m_hash_code, entry1->m_name, entry1->m_value);
                 const std::size_t index = entry1->m_hash_code % kBucketSize;
 
-                entry2->m_next = 0;
+                entry2->m_next = nullptr;
                 if ((entry2->m_previous = m_back))
                 {
                     m_back->m_next = entry2;
@@ -325,7 +325,7 @@ namespace tempearly
                 }
             }
 
-            return 0;
+            return nullptr;
         }
 
         /**
@@ -347,7 +347,7 @@ namespace tempearly
                 }
             }
 
-            return 0;
+            return nullptr;
         }
 
         /**
@@ -372,7 +372,7 @@ namespace tempearly
                 }
             }
             entry = new Entry(hash, id, value);
-            entry->m_next = 0;
+            entry->m_next = nullptr;
             if ((entry->m_previous = m_back))
             {
                 m_back->m_next = entry;
@@ -394,7 +394,7 @@ namespace tempearly
 
             for (std::size_t i = 0; i < kBucketSize; ++i)
             {
-                m_bucket[i] = 0;
+                m_bucket[i] = nullptr;
             }
             while (current)
             {
@@ -402,7 +402,7 @@ namespace tempearly
                 delete current;
                 current = next;
             }
-            m_front = m_back = 0;
+            m_front = m_back = nullptr;
         }
 
         /**
@@ -430,15 +430,15 @@ namespace tempearly
                 }
                 else if (entry->m_next)
                 {
-                    entry->m_next->m_previous = 0;
+                    entry->m_next->m_previous = nullptr;
                     m_front = entry->m_next;
                 }
                 else if (entry->m_previous)
                 {
-                    entry->m_previous->m_next = 0;
+                    entry->m_previous->m_next = nullptr;
                     m_back = entry->m_previous;
                 } else {
-                    m_front = m_back = 0;
+                    m_front = m_back = nullptr;
                 }
                 delete entry;
                 return;
@@ -457,15 +457,15 @@ namespace tempearly
                     }
                     else if (child->m_next)
                     {
-                        child->m_next->m_previous = 0;
+                        child->m_next->m_previous = nullptr;
                         m_front = child->m_next;
                     }
                     else if (child->m_previous)
                     {
-                        child->m_previous->m_next = 0;
+                        child->m_previous->m_next = nullptr;
                         m_back = child->m_previous;
                     } else {
-                        m_front = m_back = 0;
+                        m_front = m_back = nullptr;
                     }
                     delete child;
                     return;

--- a/src/core/parser.cc
+++ b/src/core/parser.cc
@@ -20,7 +20,7 @@ namespace tempearly
         if (m_stream)
         {
             m_stream->Close();
-            m_stream = 0;
+            m_stream = nullptr;
         }
     }
 
@@ -65,7 +65,7 @@ namespace tempearly
             if (result != Stream::SUCCESS && result != Stream::DECODING_ERROR)
             {
                 m_stream->Close();
-                m_stream = 0;
+                m_stream = nullptr;
 
                 return -1;
             }

--- a/src/core/string.cc
+++ b/src/core/string.cc
@@ -29,8 +29,8 @@ namespace tempearly
     String::String()
         : m_offset(0)
         , m_length(0)
-        , m_runes(0)
-        , m_counter(0)
+        , m_runes(nullptr)
+        , m_counter(nullptr)
         , m_hash_code(0) {}
 
     String::String(const String& that)
@@ -83,8 +83,8 @@ namespace tempearly
     String::String(const char* input)
         : m_offset(0)
         , m_length(0)
-        , m_runes(0)
-        , m_counter(0)
+        , m_runes(nullptr)
+        , m_counter(nullptr)
         , m_hash_code(0)
     {
         const char* p = input;
@@ -176,7 +176,7 @@ namespace tempearly
         : m_offset(0)
         , m_length(n)
         , m_runes(Memory::Allocate<rune>(m_length))
-        , m_counter(m_length ? Memory::Allocate<unsigned int>(1) : 0)
+        , m_counter(m_length ? Memory::Allocate<unsigned int>(1) : nullptr)
         , m_hash_code(0)
     {
         if (m_counter)
@@ -190,7 +190,7 @@ namespace tempearly
         : m_offset(0)
         , m_length(n)
         , m_runes(Memory::Allocate<rune>(m_length))
-        , m_counter(m_length ? Memory::Allocate<unsigned int>(1) : 0)
+        , m_counter(m_length ? Memory::Allocate<unsigned int>(1) : nullptr)
         , m_hash_code(0)
     {
         if (m_counter)
@@ -785,8 +785,8 @@ namespace tempearly
             Memory::Unallocate<unsigned int>(m_counter);
         }
         m_offset = m_length = m_hash_code = 0;
-        m_runes = 0;
-        m_counter = 0;
+        m_runes = nullptr;
+        m_counter = nullptr;
     }
 
     String String::Concat(const String& that) const

--- a/src/core/string.h
+++ b/src/core/string.h
@@ -143,7 +143,7 @@ namespace tempearly
          */
         inline const rune* GetRunes() const
         {
-            return m_runes ? m_runes + m_offset : 0;
+            return m_runes ? m_runes + m_offset : nullptr;
         }
 
         /**

--- a/src/core/vector.h
+++ b/src/core/vector.h
@@ -18,7 +18,7 @@ namespace tempearly
         Vector()
             : m_capacity(0)
             , m_size(0)
-            , m_data(0) {}
+            , m_data(nullptr) {}
 
         /**
          * Copy constructor. Contents of the existing vector are copied in the

--- a/src/coreobject.cc
+++ b/src/coreobject.cc
@@ -4,15 +4,15 @@
 namespace tempearly
 {
     CoreObject::CoreObject()
-        : m_value_head(0)
-        , m_value_tail(0) {}
+        : m_value_head(nullptr)
+        , m_value_tail(nullptr) {}
 
     CoreObject::~CoreObject()
     {
         for (Value* value = m_value_head; value; value = value->m_next)
         {
             value->m_kind = Value::KIND_NULL;
-            value->m_previous = value->m_next = 0;
+            value->m_previous = value->m_next = nullptr;
         }
     }
 
@@ -50,15 +50,15 @@ namespace tempearly
         else if (value->m_next)
         {
             m_value_head = value->m_next;
-            m_value_head->m_previous = 0;
+            m_value_head->m_previous = nullptr;
         }
         else if (value->m_previous)
         {
             m_value_tail = value->m_previous;
-            m_value_tail->m_next = 0;
+            m_value_tail->m_next = nullptr;
         } else {
-            m_value_head = m_value_tail = 0;
+            m_value_head = m_value_tail = nullptr;
         }
-        value->m_previous = value->m_next = 0;
+        value->m_previous = value->m_next = nullptr;
     }
 }

--- a/src/frame.cc
+++ b/src/frame.cc
@@ -9,7 +9,7 @@ namespace tempearly
         : m_previous(previous.Get())
         , m_enclosing_frame(enclosing_frame.Get())
         , m_function(function.Get())
-        , m_local_variables(0) {}
+        , m_local_variables(nullptr) {}
 
     Frame::~Frame()
     {

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -32,12 +32,12 @@ namespace tempearly
     void init_void(Interpreter*);
 
     Interpreter::Interpreter()
-        : request(0)
-        , response(0)
-        , m_frame(0)
-        , m_global_variables(0)
-        , m_empty_iterator(0)
-        , m_imported_files(0) {}
+        : request(nullptr)
+        , response(nullptr)
+        , m_frame(nullptr)
+        , m_global_variables(nullptr)
+        , m_empty_iterator(nullptr)
+        , m_imported_files(nullptr) {}
 
     Interpreter::~Interpreter()
     {

--- a/src/io/stream.cc
+++ b/src/io/stream.cc
@@ -14,17 +14,14 @@ namespace tempearly
 
     Stream::Stream(std::size_t buffer_size)
         : m_buffer_size(buffer_size)
-        , m_buffer(m_buffer_size ? static_cast<byte*>(std::malloc(m_buffer_size)) : 0)
+        , m_buffer(Memory::Allocate<byte>(m_buffer_size))
         , m_offset(0)
         , m_remain(0)
         , m_line(1) {}
 
     Stream::~Stream()
     {
-        if (m_buffer)
-        {
-            std::free(static_cast<void*>(m_buffer));
-        }
+        Memory::Unallocate<byte>(m_buffer);
     }
 
     void Stream::Flush()

--- a/src/memory.cc
+++ b/src/memory.cc
@@ -32,7 +32,7 @@ namespace tempearly
 
             explicit Generation()
                 : counter(0)
-                , m_head(0) {}
+                , m_head(nullptr) {}
 
             ~Generation()
             {
@@ -73,8 +73,8 @@ namespace tempearly
 #endif
                 Slot* current = m_head;
                 Slot* next;
-                Slot* saved_head = 0;
-                Slot* saved_tail = 0;
+                Slot* saved_head = nullptr;
+                Slot* saved_tail = nullptr;
 
                 m_head = 0;
                 for (; current; current = next)
@@ -82,7 +82,7 @@ namespace tempearly
                     next = current->next;
                     if (current->object->IsMarked())
                     {
-                        current->next = 0;
+                        current->next = nullptr;
                         if (saved_tail)
                         {
                             saved_tail->next = current;
@@ -146,14 +146,14 @@ namespace tempearly
     CountedObject::CountedObject()
         : m_flags(0)
         , m_reference_count(0)
-        , m_handle_head(0)
-        , m_handle_tail(0) {}
+        , m_handle_head(nullptr)
+        , m_handle_tail(nullptr) {}
 
     CountedObject::~CountedObject()
     {
         for (Handle<CountedObject>* handle = m_handle_head; handle; handle = handle->m_next)
         {
-            handle->m_pointer = 0;
+            handle->m_pointer = nullptr;
         }
     }
 

--- a/src/memory.h
+++ b/src/memory.h
@@ -34,7 +34,7 @@ namespace tempearly
                 }
             }
 
-            return 0;
+            return nullptr;
         }
 
         /**
@@ -98,17 +98,17 @@ namespace tempearly
          * Constructs NULL handle.
          */
         Handle()
-            : m_pointer(0)
-            , m_previous(0)
-            , m_next(0) {}
+            : m_pointer(nullptr)
+            , m_previous(nullptr)
+            , m_next(nullptr) {}
 
         /**
          * Copy constructor.
          */
         Handle(const Handle<T>& that)
             : m_pointer(that.m_pointer)
-            , m_previous(0)
-            , m_next(0)
+            , m_previous(nullptr)
+            , m_next(nullptr)
         {
             if (m_pointer)
             {
@@ -122,8 +122,8 @@ namespace tempearly
         template< class U >
         Handle(const Handle<U>& that)
             : m_pointer(that.Get())
-            , m_previous(0)
-            , m_next(0)
+            , m_previous(nullptr)
+            , m_next(nullptr)
         {
             if (m_pointer)
             {
@@ -137,8 +137,8 @@ namespace tempearly
         template< class U >
         Handle(U* pointer)
             : m_pointer(pointer)
-            , m_previous(0)
-            , m_next(0)
+            , m_previous(nullptr)
+            , m_next(nullptr)
         {
             if (m_pointer)
             {
@@ -424,16 +424,16 @@ namespace tempearly
             else if (handle->m_next)
             {
                 m_handle_head = handle->m_next;
-                m_handle_head->m_previous = 0;
+                m_handle_head->m_previous = nullptr;
             }
             else if (handle->m_previous)
             {
                 m_handle_tail = handle->m_previous;
-                m_handle_tail->m_next = 0;
+                m_handle_tail->m_next = nullptr;
             } else {
-                m_handle_head = m_handle_tail = 0;
+                m_handle_head = m_handle_tail = nullptr;
             }
-            handle->m_previous = handle->m_next = 0;
+            handle->m_previous = handle->m_next = nullptr;
         }
 
         static void* operator new(std::size_t);

--- a/src/sapi/apache/mod_tempearly.cc
+++ b/src/sapi/apache/mod_tempearly.cc
@@ -63,11 +63,11 @@ extern "C"
     module AP_MODULE_DECLARE_DATA tempearly_module =
     {
         STANDARD20_MODULE_STUFF,
-        0,
-        0,
-        0,
-        0,
-        0,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
         tempearly_register_hooks
     };
 }

--- a/src/sapi/apache/request.cc
+++ b/src/sapi/apache/request.cc
@@ -15,7 +15,7 @@ namespace tempearly
     ApacheRequest::ApacheRequest(request_rec* request)
         : m_request(request)
         , m_method(parse_method(request))
-        , m_body(0) {}
+        , m_body(nullptr) {}
 
     ApacheRequest::~ApacheRequest()
     {

--- a/src/sapi/cgi/request.cc
+++ b/src/sapi/cgi/request.cc
@@ -23,7 +23,7 @@ namespace tempearly
         : m_server_port(-1)
         , m_content_length(0)
         , m_using_https(false)
-        , m_body(0)
+        , m_body(nullptr)
     {
         ReadEnvironmentVariables();
         ReadBody();

--- a/src/sapi/httpd/request.cc
+++ b/src/sapi/httpd/request.cc
@@ -16,7 +16,7 @@ namespace tempearly
         , m_path(path)
         , m_query_string(query_string)
         , m_headers(headers)
-        , m_body(0)
+        , m_body(nullptr)
     {
         if (body_size)
         {

--- a/src/sapi/httpd/server.cc
+++ b/src/sapi/httpd/server.cc
@@ -60,7 +60,7 @@ namespace tempearly
         if (m_socket)
         {
             m_socket->Close();
-            m_socket = 0;
+            m_socket = nullptr;
         }
     }
 
@@ -389,7 +389,7 @@ namespace tempearly
             }
             else if (!parse_request_header(request, client, begin, end - begin))
             {
-                return 0;
+                return nullptr;
             }
         }
     }

--- a/src/value.cc
+++ b/src/value.cc
@@ -7,13 +7,13 @@ namespace tempearly
 {
     Value::Value()
         : m_kind(KIND_ERROR)
-        , m_previous(0)
-        , m_next(0) {}
+        , m_previous(nullptr)
+        , m_next(nullptr) {}
 
     Value::Value(const Value& that)
         : m_kind(that.m_kind)
-        , m_previous(0)
-        , m_next(0)
+        , m_previous(nullptr)
+        , m_next(nullptr)
     {
         switch (m_kind)
         {
@@ -51,8 +51,8 @@ namespace tempearly
 
     Value::Value(const Handle<CoreObject>& object)
         : m_kind(KIND_NULL)
-        , m_previous(0)
-        , m_next(0)
+        , m_previous(nullptr)
+        , m_next(nullptr)
     {
         if (object)
         {


### PR DESCRIPTION
Now that we can use features from C++11, let's change every unsafe `0`
and `NULL` into much type safer `nullptr`.