### PR TITLE
C++11: Add move constructors and operators.

### DIFF
--- a/src/core/dictionary.h
+++ b/src/core/dictionary.h
@@ -174,6 +174,19 @@ namespace tempearly
         }
 
         /**
+         * Move constructor. Data from another dictionary is moved into this
+         * one and the original becomes unusable after that.
+         */
+        Dictionary(Dictionary<T>&& that)
+            : m_bucket(that.m_bucket)
+            , m_front(that.m_front)
+            , m_back(that.m_back)
+        {
+            that.m_bucket = nullptr;
+            that.m_front = that.m_back = nullptr;
+        }
+
+        /**
          * Destructor.
          */
         virtual ~Dictionary()
@@ -260,6 +273,30 @@ namespace tempearly
         inline Dictionary& operator=(const Dictionary<U>& that)
         {
             return Assign(that);
+        }
+
+        /**
+         * Move operator.
+         */
+        Dictionary& operator=(Dictionary<T>&& that)
+        {
+            Entry* current = m_front;
+            Entry* next;
+
+            while (current)
+            {
+                next = current->m_next;
+                delete current;
+                current = next;
+            }
+            Memory::Unallocate<Entry*>(m_bucket);
+            m_bucket = that.m_bucket;
+            m_front = that.m_front;
+            m_back = that.m_back;
+            that.m_bucket = nullptr;
+            that.m_front = that.m_back = nullptr;
+
+            return *this;
         }
 
         /**

--- a/src/core/string.cc
+++ b/src/core/string.cc
@@ -46,6 +46,18 @@ namespace tempearly
         }
     }
 
+    String::String(String&& that)
+        : m_offset(that.m_offset)
+        , m_length(that.m_length)
+        , m_runes(that.m_runes)
+        , m_counter(that.m_counter)
+        , m_hash_code(that.m_hash_code)
+    {
+        that.m_offset = that.m_length = that.m_hash_code = 0;
+        that.m_runes = nullptr;
+        that.m_counter = nullptr;
+    }
+
     static inline std::size_t utf8_size(unsigned char input)
     {
         if ((input & 0x80) == 0x00)
@@ -421,6 +433,25 @@ namespace tempearly
                 }
             }
         }
+
+        return *this;
+    }
+
+    String& String::operator=(String&& that)
+    {
+        if (m_counter && --m_counter[0] == 0)
+        {
+            Memory::Unallocate<rune>(m_runes);
+            Memory::Unallocate<unsigned int>(m_counter);
+        }
+        m_offset = that.m_offset;
+        m_length = that.m_length;
+        m_runes = that.m_runes;
+        m_counter = that.m_counter;
+        m_hash_code = that.m_hash_code;
+        that.m_offset = that.m_length = that.m_hash_code = 0;
+        that.m_runes = nullptr;
+        that.m_counter = nullptr;
 
         return *this;
     }

--- a/src/core/string.h
+++ b/src/core/string.h
@@ -31,6 +31,11 @@ namespace tempearly
         String(const String& that);
 
         /**
+         * Moves data from another string into this one.
+         */
+        String(String&& that);
+
+        /**
          * Constructs string from C string literal. The input is expected to be
          * in UTF-8.
          */
@@ -120,6 +125,11 @@ namespace tempearly
         {
             return Assign(input);
         }
+
+        /**
+         * Move operator.
+         */
+        String& operator=(String&& that);
 
         /**
          * Returns true if the string is empty.

--- a/src/core/vector.h
+++ b/src/core/vector.h
@@ -56,6 +56,19 @@ namespace tempearly
         }
 
         /**
+         * Move constructor. Data is being moved from another vector into this
+         * one.
+         */
+        Vector(Vector<T>&& that)
+            : m_capacity(that.m_capacity)
+            , m_size(that.m_size)
+            , m_data(that.m_data)
+        {
+            that.m_capacity = that.m_size = 0;
+            that.m_data = nullptr;
+        }
+
+        /**
          * Constructs an vector which contains <i>n</i> copies of the given
          * element.
          */
@@ -153,6 +166,25 @@ namespace tempearly
         Vector& operator=(const Vector<U>& that)
         {
             return Assign(that);
+        }
+
+        /**
+         * Move operator.
+         */
+        Vector& operator=(Vector<T>&& that)
+        {
+            for (std::size_t i = 0; i < m_size; ++i)
+            {
+                m_data[i].~T();
+            }
+            Memory::Unallocate<T>(m_data);
+            m_capacity = that.m_capacity;
+            m_size = that.m_size;
+            m_data = that.m_data;
+            that.m_capacity = that.m_size = 0;
+            that.m_data = nullptr;
+
+            return *this;
         }
 
         /**

--- a/src/macros.h
+++ b/src/macros.h
@@ -3,7 +3,9 @@
 
 #define TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(TypeName) \
     TypeName(const TypeName &) = delete; \
-    void operator=(const TypeName &) = delete
+    TypeName(TypeName &&) = delete; \
+    void operator=(const TypeName &) = delete; \
+    void operator=(TypeName &&) = delete
 
 #define TEMPEARLY_DISALLOW_IMPLICIT_CONSTRUCTORS(TypeName) \
     TypeName() = delete; \

--- a/src/memory.h
+++ b/src/memory.h
@@ -132,6 +132,18 @@ namespace tempearly
         }
 
         /**
+         * Move constructor.
+         */
+        Handle(Handle<T>&& that)
+            : m_pointer(that.m_pointer)
+            , m_previous(that.m_previous)
+            , m_next(that.m_next)
+        {
+            that.m_pointer = nullptr;
+            that.m_previous = that.m_next = nullptr;
+        }
+
+        /**
          * Constructs handle from pointer to an object.
          */
         template< class U >
@@ -222,6 +234,20 @@ namespace tempearly
                     m_pointer->RegisterHandle(this);
                 }
             }
+
+            return *this;
+        }
+
+        /**
+         * Moves data from another handle into this one.
+         */
+        Handle& operator=(Handle<T>&& that)
+        {
+            m_pointer = that.m_pointer;
+            m_previous = that.m_previous;
+            m_next = that.m_next;
+            that.m_pointer = nullptr;
+            that.m_previous = that.m_next = nullptr;
 
             return *this;
         }

--- a/src/value.cc
+++ b/src/value.cc
@@ -49,6 +49,16 @@ namespace tempearly
         }
     }
 
+    Value::Value(Value&& that)
+        : m_kind(that.m_kind)
+        , m_data(that.m_data)
+        , m_previous(that.m_previous)
+        , m_next(that.m_next)
+    {
+        that.m_kind = KIND_ERROR;
+        that.m_previous = that.m_next = nullptr;
+    }
+
     Value::Value(const Handle<CoreObject>& object)
         : m_kind(KIND_NULL)
         , m_previous(nullptr)
@@ -178,6 +188,19 @@ namespace tempearly
             default:
                 break;
         }
+
+        return *this;
+    }
+
+    Value& Value::operator=(Value&& that)
+    {
+        Clear();
+        m_kind = that.m_kind;
+        m_data = that.m_data;
+        m_previous = that.m_previous;
+        m_next = that.m_next;
+        that.m_kind = KIND_ERROR;
+        that.m_previous = that.m_next = nullptr;
 
         return *this;
     }

--- a/src/value.h
+++ b/src/value.h
@@ -41,6 +41,11 @@ namespace tempearly
         Value(const Value& that);
 
         /**
+         * Move constructor. Data from another value are moved into this one.
+         */
+        Value(Value&& that);
+
+        /**
          * Constructs value from object.
          *
          * \param object Handle to the object
@@ -86,6 +91,11 @@ namespace tempearly
          * Assignment operator.
          */
         Value& operator=(const Value& that);
+
+        /**
+         * Move operator.
+         */
+        Value& operator=(Value&& that);
 
         /**
          * Assignment operator.


### PR DESCRIPTION
This commit adds move constructors and operators for some of the most
commonly used classes in order to avoid usage of copy constructors and
assignment operators.

Also modifies `DISALLOW_COPY_AND_ASSIGN` macro so that it deletes
default move constructor and operator if they are present.