### PR TITLE
Redesign of Value, Frame and FunctionObject classes.

### DIFF
--- a/src/api/class.cc
+++ b/src/api/class.cc
@@ -173,12 +173,7 @@ namespace tempearly
                 {
                     return false;
                 }
-                else if (frame->HasReturnValue())
-                {
-                    slot = frame->GetReturnValue();
-                } else {
-                    slot = Value::NullValue();
-                }
+                slot = frame->GetReturnValue();
 
                 return true;
             }
@@ -268,12 +263,7 @@ namespace tempearly
                 {
                     return false;
                 }
-                else if (frame->HasReturnValue())
-                {
-                    slot = frame->GetReturnValue();
-                } else {
-                    slot = Value::NullValue();
-                }
+                slot = frame->GetReturnValue();
 
                 return true;
             }
@@ -335,7 +325,7 @@ namespace tempearly
                     return false;
                 }
 
-                return slot = args[0].Call(interpreter, m_alias, args.SubVector(1));
+                return args[0].CallMethod(interpreter, slot, m_alias, args.SubVector(1));
             }
 
         private:
@@ -424,9 +414,10 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(class_call)
     {
-        Value instance = args[0].Call(interpreter, "alloc");
+        Value instance;
 
-        if (instance && instance.Call(interpreter, "__init__", args.SubVector(1)))
+        if (args[0].CallMethod(interpreter, instance, "alloc")
+            && instance.CallMethod(interpreter, "__init__", args.SubVector(1)))
         {
             frame->SetReturnValue(instance);
         }

--- a/src/api/class.cc
+++ b/src/api/class.cc
@@ -57,16 +57,6 @@ namespace tempearly
         }
     }
 
-    bool Class::HasAttribute(const String& id) const
-    {
-        if (m_attributes && m_attributes->Find(id))
-        {
-            return true;
-        } else {
-            return m_base && m_base->HasAttribute(id);
-        }
-    }
-
     bool Class::GetAttribute(const String& id, Value& value) const
     {
         if (m_attributes)
@@ -97,116 +87,23 @@ namespace tempearly
         m_attributes->Insert(id, value);
     }
 
-    namespace
-    {
-        class Method : public FunctionObject
-        {
-        public:
-            explicit Method(const Handle<Interpreter>& interpreter,
-                            const Handle<Class>& declaring_class,
-                            int arity,
-                            Callback callback)
-                : FunctionObject(interpreter)
-                , m_declaring_class(declaring_class.Get())
-                , m_arity(arity)
-                , m_callback(callback) {}
-
-            bool Invoke(const Handle<Interpreter>& interpreter, const Vector<Value>& args, Value& slot)
-            {
-                Handle<Frame> frame = interpreter->PushFrame(Handle<Frame>(), this, args);
-
-                // Arguments must not be empty.
-                if (args.IsEmpty())
-                {
-                    interpreter->Throw(interpreter->eTypeError, "Missing method receiver");
-                    interpreter->PopFrame();
-
-                    return false;
-                }
-                // Test that the first argument is correct type.
-                else if (!args[0].IsInstance(interpreter, m_declaring_class))
-                {
-                    interpreter->Throw(
-                        interpreter->eTypeError,
-                        "Method requires a '"
-                        + m_declaring_class->GetName()
-                        + "' object but received a '"
-                        + args[0].GetClass(interpreter)->GetName()
-                    );
-                    interpreter->PopFrame();
-
-                    return false;
-                }
-                // Test that we have correct amount of arguments.
-                else if (m_arity < 0)
-                {
-                    if (args.GetSize() < static_cast<unsigned>(-(m_arity + 1) + 1))
-                    {
-                        interpreter->Throw(
-                            interpreter->eTypeError,
-                            "Method expected at least "
-                            + String::FromI64(-m_arity - 1)
-                            + " arguments, got "
-                            + String::FromU64(args.GetSize())
-                        );
-                        interpreter->PopFrame();
-
-                        return false;
-                    }
-                }
-                else if (args.GetSize() != static_cast<unsigned>(m_arity) + 1)
-                {
-                    interpreter->Throw(
-                        interpreter->eTypeError,
-                        "Method expected "
-                        + String::FromI64(m_arity)
-                        + " arguments, got "
-                        + String::FromU64(args.GetSize())
-                    );
-                    interpreter->PopFrame();
-
-                    return false;
-                }
-                m_callback(interpreter, frame, args);
-                interpreter->PopFrame();
-                if (interpreter->HasException())
-                {
-                    return false;
-                }
-                slot = frame->GetReturnValue();
-
-                return true;
-            }
-
-            void Mark()
-            {
-                FunctionObject::Mark();
-                if (!m_declaring_class->IsMarked())
-                {
-                    m_declaring_class->Mark();
-                }
-            }
-
-        private:
-            Class* m_declaring_class;
-            const int m_arity;
-            const Callback m_callback;
-            TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(Method);
-        };
-    }
-
     void Class::AddMethod(const Handle<Interpreter>& interpreter,
                           const String& name,
                           int arity,
                           MethodCallback callback)
     {
-        Value method = Value(new Method(interpreter, this, arity, callback));
+        Handle<FunctionObject> method = FunctionObject::NewUnboundMethod(
+            interpreter,
+            this,
+            arity,
+            callback
+        );
 
         if (!m_attributes)
         {
             m_attributes = new AttributeMap();
         }
-        m_attributes->Insert(name, method);
+        m_attributes->Insert(name, Value(method));
     }
 
     namespace
@@ -223,9 +120,10 @@ namespace tempearly
                 , m_arity(arity)
                 , m_callback(callback) {}
 
-            bool Invoke(const Handle<Interpreter>& interpreter, const Vector<Value>& args, Value& slot)
+            bool Invoke(const Handle<Interpreter>& interpreter,
+                        const Handle<Frame>& frame)
             {
-                Handle<Frame> frame = interpreter->PushFrame(Handle<Frame>(), this, args);
+                const Vector<Value>& args = frame->GetArguments();
 
                 // Test that we have correct amount of arguments.
                 if (m_arity < 0)
@@ -239,7 +137,6 @@ namespace tempearly
                             + " arguments, got "
                             + String::FromU64(args.GetSize())
                         );
-                        interpreter->PopFrame();
 
                         return false;
                     }
@@ -253,24 +150,12 @@ namespace tempearly
                         + " arguments, got "
                         + String::FromU64(args.GetSize())
                     );
-                    interpreter->PopFrame();
 
                     return false;
                 }
                 m_callback(interpreter, frame, args);
-                interpreter->PopFrame();
-                if (interpreter->HasException())
-                {
-                    return false;
-                }
-                slot = frame->GetReturnValue();
 
-                return true;
-            }
-
-            bool IsStaticMethod() const
-            {
-                return true;
+                return !interpreter->HasException();
             }
 
             void Mark()
@@ -313,19 +198,37 @@ namespace tempearly
                 : FunctionObject(interpreter)
                 , m_alias(alias) {}
 
-            bool Invoke(const Handle<Interpreter>& interpreter, const Vector<Value>& args, Value& slot)
+            bool Invoke(const Handle<Interpreter>& interpreter,
+                        const Handle<Frame>& frame)
             {
+                const Vector<Value>& args = frame->GetArguments();
+                Value result;
+
                 // Arguments must not be empty.
                 if (args.IsEmpty())
                 {
-                    interpreter->PushFrame(Handle<Frame>(), this);
-                    interpreter->Throw(interpreter->eTypeError, "Missing method receiver");
-                    interpreter->PopFrame();
+                    interpreter->Throw(
+                        interpreter->eTypeError,
+                        "Missing method receiver"
+                    );
 
                     return false;
                 }
+                if (!args[0].CallMethod(interpreter,
+                                        result,
+                                        m_alias,
+                                        args.SubVector(1)))
+                {
+                    return false;
+                }
+                frame->SetReturnValue(result);
 
-                return args[0].CallMethod(interpreter, slot, m_alias, args.SubVector(1));
+                return true;
+            }
+
+            bool IsUnboundMethod() const
+            {
+                return true;
             }
 
         private:

--- a/src/api/class.cc
+++ b/src/api/class.cc
@@ -113,7 +113,7 @@ namespace tempearly
 
             bool Invoke(const Handle<Interpreter>& interpreter, const Vector<Value>& args, Value& slot)
             {
-                Handle<Frame> frame = interpreter->PushFrame(Handle<Frame>(), this);
+                Handle<Frame> frame = interpreter->PushFrame(Handle<Frame>(), this, args);
 
                 // Arguments must not be empty.
                 if (args.IsEmpty())
@@ -225,7 +225,7 @@ namespace tempearly
 
             bool Invoke(const Handle<Interpreter>& interpreter, const Vector<Value>& args, Value& slot)
             {
-                Handle<Frame> frame = interpreter->PushFrame(Handle<Frame>(), this);
+                Handle<Frame> frame = interpreter->PushFrame(Handle<Frame>(), this, args);
 
                 // Test that we have correct amount of arguments.
                 if (m_arity < 0)

--- a/src/api/class.h
+++ b/src/api/class.h
@@ -51,8 +51,6 @@ namespace tempearly
 
         Dictionary<Value> GetAllAttributes() const;
 
-        bool HasAttribute(const String& id) const;
-
         bool GetAttribute(const String& id, Value& value) const;
 
         void SetAttribute(const String& id, const Value& value);

--- a/src/api/file.cc
+++ b/src/api/file.cc
@@ -646,9 +646,14 @@ namespace tempearly
             return;
         }
         stream_object = new FileStreamObject(interpreter, stream, binary);
-        if (function)
+        if (!function.IsNull())
         {
-            frame->SetReturnValue(function.Call(interpreter, "__call__", Vector<Value>(1, Value(stream_object))));
+            Value result;
+
+            if (function.CallMethod(interpreter, result, "__call__", Value(stream_object)))
+            {
+                frame->SetReturnValue(result);
+            }
             stream_object->Close();
         } else {
             frame->SetReturnValue(Value(stream_object));

--- a/src/api/function.cc
+++ b/src/api/function.cc
@@ -24,7 +24,7 @@ namespace tempearly
 
             bool Invoke(const Handle<Interpreter>& interpreter, const Vector<Value>& args, Value& slot)
             {
-                interpreter->PushFrame(m_enclosing_frame, this);
+                interpreter->PushFrame(m_enclosing_frame, this, args);
                 if (!Parameter::Apply(interpreter, m_parameters, args))
                 {
                     interpreter->PopFrame();

--- a/src/api/function.cc
+++ b/src/api/function.cc
@@ -29,7 +29,7 @@ namespace tempearly
                 {
                     interpreter->PopFrame();
 
-                    return Value();
+                    return false;
                 }
                 for (std::size_t i = 0; i < m_nodes.GetSize(); ++i)
                 {
@@ -42,12 +42,7 @@ namespace tempearly
 
                         case Result::KIND_RETURN:
                             interpreter->PopFrame();
-                            if (result.HasValue())
-                            {
-                                slot = result.GetValue();
-                            } else {
-                                slot = Value::NullValue();
-                            }
+                            slot = result.GetValue();
                             return true;
 
                         case Result::KIND_BREAK:
@@ -66,7 +61,7 @@ namespace tempearly
                     }
                 }
                 interpreter->PopFrame();
-                slot = Value::NullValue();
+                slot.Clear();
 
                 return true;
             }

--- a/src/api/function.cc
+++ b/src/api/function.cc
@@ -4,8 +4,10 @@
 
 namespace tempearly
 {
-    FunctionObject::FunctionObject(const Handle<Interpreter>& interpreter)
-        : Object(interpreter->cFunction) {}
+    FunctionObject::FunctionObject(const Handle<Interpreter>& interpreter,
+                                   const Handle<Frame>& enclosing_frame)
+        : Object(interpreter->cFunction)
+        , m_enclosing_frame(enclosing_frame) {}
 
     FunctionObject::~FunctionObject() {}
 
@@ -17,51 +19,50 @@ namespace tempearly
             explicit ScriptedFunction(const Handle<Interpreter>& interpreter,
                                       const Vector<Handle<Parameter> >& parameters,
                                       const Vector<Handle<Node> >& nodes)
-                : FunctionObject(interpreter)
-                , m_enclosing_frame(interpreter->GetFrame())
+                : FunctionObject(interpreter, interpreter->GetFrame())
                 , m_parameters(parameters)
                 , m_nodes(nodes) {}
 
-            bool Invoke(const Handle<Interpreter>& interpreter, const Vector<Value>& args, Value& slot)
+            bool Invoke(const Handle<Interpreter>& interpreter,
+                        const Handle<Frame>& frame)
             {
-                interpreter->PushFrame(m_enclosing_frame, this, args);
-                if (!Parameter::Apply(interpreter, m_parameters, args))
+                if (!Parameter::Apply(interpreter,
+                                      m_parameters,
+                                      frame->GetArguments()))
                 {
-                    interpreter->PopFrame();
-
                     return false;
                 }
                 for (std::size_t i = 0; i < m_nodes.GetSize(); ++i)
                 {
-                    Result result = m_nodes[i]->Execute(interpreter);
+                    const Result result = m_nodes[i]->Execute(interpreter);
 
                     switch (result.GetKind())
                     {
                         case Result::KIND_SUCCESS:
-                            break;
+                            continue;
 
                         case Result::KIND_RETURN:
-                            interpreter->PopFrame();
-                            slot = result.GetValue();
+                            frame->SetReturnValue(result.GetValue());
                             return true;
 
                         case Result::KIND_BREAK:
-                            interpreter->Throw(interpreter->eSyntaxError, "Unexpected 'break'");
-                            interpreter->PopFrame();
+                            interpreter->Throw(
+                                interpreter->eSyntaxError,
+                                "Unexpected 'break'"
+                            );
                             return false;
 
                         case Result::KIND_CONTINUE:
-                            interpreter->Throw(interpreter->eSyntaxError, "Unexpected 'continue'");
-                            interpreter->PopFrame();
+                            interpreter->Throw(
+                                interpreter->eSyntaxError,
+                                "Unexpected 'continue'"
+                            );
                             return false;
 
                         default:
-                            interpreter->PopFrame();
                             return false;
                     }
                 }
-                interpreter->PopFrame();
-                slot.Clear();
 
                 return true;
             }
@@ -69,10 +70,6 @@ namespace tempearly
             void Mark()
             {
                 FunctionObject::Mark();
-                if (m_enclosing_frame && !m_enclosing_frame->IsMarked())
-                {
-                    m_enclosing_frame->Mark();
-                }
                 for (std::size_t i = 0; i < m_parameters.GetSize(); ++i)
                 {
                     if (!m_parameters[i]->IsMarked())
@@ -90,7 +87,6 @@ namespace tempearly
             }
 
         private:
-            Frame* m_enclosing_frame;
             const Vector<Parameter*> m_parameters;
             const Vector<Node*> m_nodes;
             TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(ScriptedFunction);
@@ -106,6 +102,148 @@ namespace tempearly
 
     namespace
     {
+        class UnboundMethod : public FunctionObject
+        {
+        public:
+            explicit UnboundMethod(const Handle<Interpreter>& interpreter,
+                                   const Handle<Class>& declaring_class,
+                                   int arity,
+                                   Callback callback)
+                : FunctionObject(interpreter)
+                , m_declaring_class(declaring_class)
+                , m_arity(arity)
+                , m_callback(callback) {}
+
+            bool Invoke(const Handle<Interpreter>& interpreter,
+                        const Handle<Frame>& frame)
+            {
+                const Vector<Value>& args = frame->GetArguments();
+
+                // Arguments must not be empty.
+                if (args.IsEmpty())
+                {
+                    interpreter->Throw(
+                        interpreter->eTypeError,
+                        "Missing method receiver"
+                    );
+
+                    return false;
+                }
+                // Test that the first argument is correct type.
+                else if (!args[0].IsInstance(interpreter, m_declaring_class))
+                {
+                    interpreter->Throw(
+                        interpreter->eTypeError,
+                        "Method requires a '"
+                        + m_declaring_class->GetName()
+                        + "' object but received a '"
+                        + args[0].GetClass(interpreter)->GetName()
+                    );
+
+                    return false;
+                }
+                // Test that we have correct amount of arguments.
+                else if (m_arity < 0)
+                {
+                    if (args.GetSize() < static_cast<unsigned>(-(m_arity + 1) + 1))
+                    {
+                        interpreter->Throw(
+                            interpreter->eTypeError,
+                            "Method expected at least "
+                            + String::FromI64(-m_arity - 1)
+                            + " arguments, got "
+                            + String::FromU64(args.GetSize())
+                        );
+
+                        return false;
+                    }
+                }
+                else if (args.GetSize() != static_cast<unsigned>(m_arity) + 1)
+                {
+                    interpreter->Throw(
+                        interpreter->eTypeError,
+                        "Method expected "
+                        + String::FromI64(m_arity)
+                        + " arguments, got "
+                        + String::FromU64(args.GetSize())
+                    );
+
+                    return false;
+                }
+                m_callback(interpreter, frame, args);
+
+                return !interpreter->HasException();
+            }
+
+            bool IsUnboundMethod() const
+            {
+                return true;
+            }
+
+            void Mark()
+            {
+                FunctionObject::Mark();
+                if (!m_declaring_class->IsMarked())
+                {
+                    m_declaring_class->Mark();
+                }
+            }
+
+        private:
+            Class* m_declaring_class;
+            const int m_arity;
+            const Callback m_callback;
+            TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(UnboundMethod);
+        };
+    }
+
+    Handle<FunctionObject> FunctionObject::NewUnboundMethod(
+        const Handle<Interpreter>& interpreter,
+        const Handle<Class>& cls,
+        int arity,
+        Callback callback
+    )
+    {
+        return new UnboundMethod(interpreter, cls, arity, callback);
+    }
+
+    bool FunctionObject::Invoke(const Handle<Interpreter>& interpreter,
+                                Value& slot,
+                                const Vector<Value>& args)
+    {
+        const Handle<Frame> frame = interpreter->PushFrame(
+            m_enclosing_frame,
+            this,
+            args
+        );
+        const bool result = Invoke(interpreter, frame);
+
+        interpreter->PopFrame();
+        if (result)
+        {
+            slot = frame->GetReturnValue();
+        }
+
+        return result;
+    }
+
+    bool FunctionObject::Invoke(const Handle<Interpreter>& interpreter,
+                                const Vector<Value>& args)
+    {
+        const Handle<Frame> frame = interpreter->PushFrame(
+            m_enclosing_frame,
+            this,
+            args
+        );
+        const bool result = Invoke(interpreter, frame);
+
+        interpreter->PopFrame();
+
+        return result;
+    }
+
+    namespace
+    {
         class CurryFunction : public FunctionObject
         {
         public:
@@ -116,9 +254,20 @@ namespace tempearly
                 , m_base(base)
                 , m_args(args) {}
 
-            bool Invoke(const Handle<Interpreter>& interpreter, const Vector<Value>& args, Value& slot)
+            bool Invoke(const Handle<Interpreter>& interpreter,
+                        const Handle<Frame>& frame)
             {
-                return m_base->Invoke(interpreter, m_args + args, slot);
+                Value result;
+
+                if (!m_base->Invoke(interpreter,
+                                    result,
+                                    m_args + frame->GetArguments()))
+                {
+                    return false;
+                }
+                frame->SetReturnValue(result);
+
+                return true;
             }
 
             void Mark()
@@ -146,6 +295,15 @@ namespace tempearly
         return Value(new CurryFunction(interpreter, this, args));
     }
 
+    void FunctionObject::Mark()
+    {
+        Object::Mark();
+        if (m_enclosing_frame && !m_enclosing_frame->IsMarked())
+        {
+            m_enclosing_frame->Mark();
+        }
+    }
+
     /**
      * Function#__call__(args...)
      *
@@ -155,7 +313,9 @@ namespace tempearly
     {
         Value result;
 
-        if (args[0].As<FunctionObject>()->Invoke(interpreter, args.SubVector(1), result))
+        if (args[0].As<FunctionObject>()->Invoke(interpreter,
+                                                 result,
+                                                 args.SubVector(1)))
         {
             frame->SetReturnValue(result);
         }

--- a/src/api/function.h
+++ b/src/api/function.h
@@ -16,7 +16,10 @@ namespace tempearly
         /**
          * Default constructor.
          */
-        explicit FunctionObject(const Handle<Interpreter>& interpreter);
+        explicit FunctionObject(
+            const Handle<Interpreter>& interpreter,
+            const Handle<Frame>& enclosing_frame = Handle<Frame>()
+        );
 
         /**
          * Default destructor.
@@ -30,24 +33,73 @@ namespace tempearly
          * \param parameters  Parameters for the function
          * \param nodes       Function body
          */
-        static Handle<FunctionObject> NewScripted(const Handle<Interpreter>& interpreter,
-                                                  const Vector<Handle<Parameter> >& parameters,
-                                                  const Vector<Handle<Node> >& nodes);
+        static Handle<FunctionObject> NewScripted(
+            const Handle<Interpreter>& interpreter,
+            const Vector<Handle<Parameter> >& parameters,
+            const Vector<Handle<Node> >& nodes
+        );
+
+        /**
+         * Constructs unbound method suitable to be added as an attribute of a
+         * class.
+         *
+         * \param interpreter Script interpreter
+         * \param cls         Class which declared the method
+         * \param arity
+         * \param callback
+         */
+        static Handle<FunctionObject> NewUnboundMethod(
+            const Handle<Interpreter>& interpreter,
+            const Handle<Class>& cls,
+            int arity,
+            Callback callback
+        );
 
         /**
          * Invokes the function.
          *
          * \param interpreter Script interpreter
-         * \param args        Arguments given for the function
          * \param slot        Where result of the function execution will be
          *                    assigned to
+         * \param args        Arguments given for the function
          * \return            A boolean flag indicating whether execution of
          *                    the function was successfull or not, or whether
          *                    an exception was thrown
          */
-        virtual bool Invoke(const Handle<Interpreter>& interpreter,
-                            const Vector<Value>& args,
-                            Value& slot) = 0;
+        bool Invoke(
+            const Handle<Interpreter>& interpreter,
+            Value& slot,
+            const Vector<Value>& args
+        );
+
+        /**
+         * Invokes the function. Return value of the function will be ignored.
+         *
+         * \param interpreter Script interpreter
+         * \param args        Arguments given for the function
+         * \return            A boolean flag indicating whether execution of
+         *                    the function was successfull or not, or whether
+         *                    an exception was thrown
+         */
+        bool Invoke(
+            const Handle<Interpreter>& interpreter,
+            const Vector<Value>& args
+        );
+
+        /**
+         * Invokes the function with already constructed stack frame.
+         *
+         * \param interpreter Script interpreter
+         * \param frame       Stack frame containing details about the function
+         *                    invocation such as arguments
+         * \return            A boolean flag indicating whether execution of
+         *                    the function was successfull or not, or whether
+         *                    an exception was thrown
+         */
+        virtual bool Invoke(
+            const Handle<Interpreter>& interpreter,
+            const Handle<Frame>& frame
+        ) = 0;
 
         /**
          * Creates curry function which uses this function as it's base.
@@ -64,7 +116,10 @@ namespace tempearly
             return true;
         }
 
+        virtual void Mark();
+
     private:
+        Frame* m_enclosing_frame;
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(FunctionObject);
     };
 }

--- a/src/api/iterable.cc
+++ b/src/api/iterable.cc
@@ -14,10 +14,10 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_first)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
         Value element;
 
-        if (!iterator)
+        if (!args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
             return;
         }
@@ -46,10 +46,10 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_last)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
         Value element;
 
-        if (!iterator)
+        if (!args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
             return;
         }
@@ -82,10 +82,10 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_single)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
         Value element;
 
-        if (!iterator)
+        if (!args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
             return;
         }
@@ -130,66 +130,66 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_max)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
+        Value max;
 
-        if (iterator)
+        if (!args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
-            Value max;
+            return;
+        }
+        if (iterator.GetNext(interpreter, max))
+        {
+            Value element;
+            Value result;
+            Vector<Value> args2;
 
-            if (iterator.GetNext(interpreter, max))
+            if (args.GetSize() < 2)
             {
-                Value element;
-                Value result;
-                Vector<Value> args2;
+                bool b;
 
-                if (args.GetSize() < 2)
+                args2.Reserve(1);
+                while (iterator.GetNext(interpreter, element))
                 {
-                    bool b;
-
-                    args2.Reserve(1);
-                    while (iterator.GetNext(interpreter, element))
+                    args2.Clear();
+                    args2.PushBack(max);
+                    if (!element.CallMethod(interpreter, result, "__gt__", args2)
+                        || !result.AsBool(interpreter, b))
                     {
-                        args2.Clear();
-                        args2.PushBack(max);
-                        if (!(result = element.Call(interpreter, "__gt__", args2))
-                            || !result.AsBool(interpreter, b))
-                        {
-                            return;
-                        }
-                        else if (b)
-                        {
-                            max = element;
-                        }
+                        return;
                     }
-                } else {
-                    i64 i;
-
-                    args2.Reserve(2);
-                    while (iterator.GetNext(interpreter, element))
+                    else if (b)
                     {
-                        args2.Clear();
-                        args2.PushBack(max);
-                        args2.PushBack(element);
-                        if (!(result = args[1].Call(interpreter, "__call__", args2))
-                            || !result.AsInt(interpreter, i))
-                        {
-                            return;
-                        }
-                        else if (i > 0)
-                        {
-                            max = element;
-                        }
+                        max = element;
                     }
                 }
-                if (!interpreter->HasException())
+            } else {
+                i64 i;
+
+                args2.Reserve(2);
+                while (iterator.GetNext(interpreter, element))
                 {
-                    frame->SetReturnValue(max);
+                    args2.Clear();
+                    args2.PushBack(max);
+                    args2.PushBack(element);
+                    if (!args[1].CallMethod(interpreter, result, "__call__", args2)
+                        || !result.AsInt(interpreter, i))
+                    {
+                        return;
+                    }
+                    else if (i > 0)
+                    {
+                        max = element;
+                    }
                 }
             }
-            else if (!interpreter->HasException())
+            if (!interpreter->HasException())
             {
-                interpreter->Throw(interpreter->eStateError, "Iteration is empty");
+                frame->SetReturnValue(max);
             }
+        }
+        else if (!interpreter->HasException())
+        {
+            interpreter->Throw(interpreter->eStateError, "Iteration is empty");
         }
     }
 
@@ -209,64 +209,66 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_min)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
+        Value min;
 
-        if (iterator)
+        if (!args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
-            Value min;
+            return;
+        }
+        if (iterator.GetNext(interpreter, min))
+        {
+            Value element;
+            Value result;
+            Vector<Value> args2;
 
-            if (iterator.GetNext(interpreter, min))
+            if (args.GetSize() < 2)
             {
-                Value element;
-                Value result;
-                Vector<Value> args2;
+                bool b;
 
-                if (args.GetSize() < 2)
+                args2.Reserve(1);
+                while (iterator.GetNext(interpreter, element))
                 {
-                    bool b;
-
-                    args2.Reserve(1);
-                    while (iterator.GetNext(interpreter, element))
+                    args2.Clear();
+                    args2.PushBack(min);
+                    if (!element.CallMethod(interpreter, result, "__lt__", args2)
+                        || !result.AsBool(interpreter, b))
                     {
-                        args2.Clear();
-                        args2.PushBack(min);
-                        if (!(result = element.Call(interpreter, "__lt__", args2)) || !result.AsBool(interpreter, b))
-                        {
-                            return;
-                        }
-                        else if (b)
-                        {
-                            min = element;
-                        }
+                        return;
                     }
-                } else {
-                    i64 i;
-
-                    args2.Reserve(2);
-                    while (iterator.GetNext(interpreter, element))
+                    else if (b)
                     {
-                        args2.Clear();
-                        args2.PushBack(min);
-                        args2.PushBack(element);
-                        if (!(result = args[1].Call(interpreter, "__call__", args2)) || !result.AsInt(interpreter, i))
-                        {
-                            return;
-                        }
-                        else if (i < 0)
-                        {
-                            min = element;
-                        }
+                        min = element;
                     }
                 }
-                if (!interpreter->HasException())
+            } else {
+                i64 i;
+
+                args2.Reserve(2);
+                while (iterator.GetNext(interpreter, element))
                 {
-                    frame->SetReturnValue(min);
+                    args2.Clear();
+                    args2.PushBack(min);
+                    args2.PushBack(element);
+                    if (!args[1].CallMethod(interpreter, result, "__call__", args2)
+                        || !result.AsInt(interpreter, i))
+                    {
+                        return;
+                    }
+                    else if (i < 0)
+                    {
+                        min = element;
+                    }
                 }
             }
-            else if (!interpreter->HasException())
+            if (!interpreter->HasException())
             {
-                interpreter->Throw(interpreter->eStateError, "Iteration is empty");
+                frame->SetReturnValue(min);
             }
+        }
+        else if (!interpreter->HasException())
+        {
+            interpreter->Throw(interpreter->eStateError, "Iteration is empty");
         }
     }
 
@@ -287,10 +289,10 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_avg)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
         Value element;
 
-        if (!iterator)
+        if (!args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
             return;
         }
@@ -307,7 +309,7 @@ namespace tempearly
                 {
                     args2.Clear();
                     args2.PushBack(element);
-                    if (!(sum = sum.Call(interpreter, "__add__", args2)))
+                    if (!sum.CallMethod(interpreter, sum, "__add__", args2))
                     {
                         return;
                     }
@@ -320,7 +322,7 @@ namespace tempearly
                     args2.Clear();
                     args2.PushBack(sum);
                     args2.PushBack(element);
-                    if (!(sum = args[1].Call(interpreter, "__call__", args2)))
+                    if (!args[1].CallMethod(interpreter, sum, "__call__", args2))
                     {
                         return;
                     }
@@ -329,9 +331,14 @@ namespace tempearly
             }
             if (!interpreter->HasException())
             {
+                Value result;
+
                 args2.Clear();
                 args2.PushBack(Value::NewInt(count));
-                frame->SetReturnValue(sum.Call(interpreter, "__div__", args2));
+                if (sum.CallMethod(interpreter, result, "__div__", args2))
+                {
+                    frame->SetReturnValue(result);
+                }
             }
         }
         else if (!interpreter->HasException())
@@ -357,14 +364,14 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_sum)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
         Value element;
 
-        if (!iterator)
+        if (!args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
             return;
         }
-        if (iterator.GetNext(interpreter, element))
+        else if (iterator.GetNext(interpreter, element))
         {
             Value sum = element;
             Vector<Value> args2;
@@ -376,7 +383,7 @@ namespace tempearly
                 {
                     args2.Clear();
                     args2.PushBack(element);
-                    if (!(sum = sum.Call(interpreter, "__add__", args2)))
+                    if (!sum.CallMethod(interpreter, sum, "__add__", args2))
                     {
                         return;
                     }
@@ -388,7 +395,7 @@ namespace tempearly
                     args2.Clear();
                     args2.PushBack(sum);
                     args2.PushBack(element);
-                    if (!(sum = args[1].Call(interpreter, "__call__", args2)))
+                    if (!args[1].CallMethod(interpreter, sum, "__call__", args2))
                     {
                         return;
                     }
@@ -416,21 +423,22 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_all)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
         Value element;
 
-        if (!iterator)
+        if (!args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
             return;
         }
-        if (iterator.GetNext(interpreter, element))
+        else if (iterator.GetNext(interpreter, element))
         {
             do
             {
-                Value result = args[1].Call(interpreter, "__call__", element);
+                Value result;
                 bool b;
 
-                if (!result || !result.AsBool(interpreter, b))
+                if (!args[1].CallMethod(interpreter, result, "__call__", element)
+                    || !result.AsBool(interpreter, b))
                 {
                     return;
                 }
@@ -463,21 +471,22 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_any)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
         Value element;
 
-        if (!iterator)
+        if (!args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
             return;
         }
-        if (iterator.GetNext(interpreter, element))
+        else if (iterator.GetNext(interpreter, element))
         {
             do
             {
-                Value result = args[1].Call(interpreter, "__call__", element);
+                Value result;
                 bool b;
 
-                if (!result || !result.AsBool(interpreter, b))
+                if (!args[1].CallMethod(interpreter, result, "__call__", element)
+                    || !result.AsBool(interpreter, b))
                 {
                     return;
                 }
@@ -503,23 +512,23 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_each)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
+        Value element;
 
-        if (iterator)
+        if (!args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
-            Value element;
-
-            while (iterator.GetNext(interpreter, element))
+            return;
+        }
+        while (iterator.GetNext(interpreter, element))
+        {
+            if (!args[1].CallMethod(interpreter, "__call__", element))
             {
-                if (!args[1].Call(interpreter, "__call__", element))
-                {
-                    return;
-                }
+                return;
             }
-            if (!interpreter->HasException())
-            {
-                frame->SetReturnValue(args[0]);
-            }
+        }
+        if (!interpreter->HasException())
+        {
+            frame->SetReturnValue(args[0]);
         }
     }
 
@@ -533,19 +542,20 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_filter)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
 
-        if (iterator)
+        if (args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
             Handle<ListObject> list = new ListObject(interpreter->cList);
             Value element;
 
             while (iterator.GetNext(interpreter, element))
             {
-                Value result = args[1].Call(interpreter, "__call__", element);
+                Value result;
                 bool b;
 
-                if (!result || !result.AsBool(interpreter, b))
+                if (!args[1].CallMethod(interpreter, result, "__call__", element)
+                    || !result.AsBool(interpreter, b))
                 {
                     return;
                 }
@@ -571,19 +581,20 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_grep)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
 
-        if (iterator)
+        if (args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
             Value element;
             Handle<ListObject> list = new ListObject(interpreter->cList);
 
             while (!iterator.GetNext(interpreter, element))
             {
-                Value result = args[1].Call(interpreter, "__case__", element);
+                Value result;
                 bool b;
 
-                if (!result || !result.AsBool(interpreter, b))
+                if (!args[1].CallMethod(interpreter, result, "__case__", element)
+                    || !result.AsBool(interpreter, b))
                 {
                     return;
                 }
@@ -610,9 +621,9 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_has)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
 
-        if (iterator)
+        if (args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
             Value element;
 
@@ -673,7 +684,7 @@ namespace tempearly
             bool first = true;
 
             args[0].SetFlag(CountedObject::FLAG_INSPECTING);
-            if (!(iterator = args[0].Call(interpreter, "__iter__")))
+            if (!args[0].CallMethod(interpreter, iterator, "__iter__"))
             {
                 args[0].UnsetFlag(CountedObject::FLAG_INSPECTING);
                 return;
@@ -714,18 +725,18 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_map)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
 
-        if (iterator)
+        if (args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
             Handle<ListObject> list = new ListObject(interpreter->cList);
             Value element;
 
             while (iterator.GetNext(interpreter, element))
             {
-                Value result = args[1].Call(interpreter, "__call__", element);
+                Value result;
 
-                if (!result)
+                if (!args[1].CallMethod(interpreter, result, "__call__", element))
                 {
                     return;
                 }
@@ -843,7 +854,8 @@ namespace tempearly
             args.Clear();
             args.PushBack(vector[left]);
             args.PushBack(vector[pivot]);
-            if (!(result = function.Call(interpreter, "__call__", args)) || !result.AsBool(interpreter, slot))
+            if (!function.CallMethod(interpreter, result, "__call__", args)
+                || !result.AsBool(interpreter, slot))
             {
                 return false;
             }
@@ -852,7 +864,8 @@ namespace tempearly
                 args.Clear();
                 args.PushBack(vector[right]);
                 args.PushBack(vector[pivot]);
-                if (!(result = function.Call(interpreter, "__call__", args)) || !result.AsBool(interpreter, slot))
+                if (!function.CallMethod(interpreter, result, "__call__", args)
+                    || !result.AsBool(interpreter, slot))
                 {
                     return false;
                 }
@@ -874,7 +887,8 @@ namespace tempearly
             args.Clear();
             args.PushBack(vector[pivot]);
             args.PushBack(vector[left]);
-            if (!(result = function.Call(interpreter, "__call__", args)) || !result.AsBool(interpreter, slot))
+            if (!function.CallMethod(interpreter, result, "__call__", args)
+                || !result.AsBool(interpreter, slot))
             {
                 return false;
             }
@@ -902,9 +916,9 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_sort)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
 
-        if (iterator)
+        if (args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
             Value element;
             Vector<Value> vector;
@@ -950,9 +964,9 @@ namespace tempearly
      */
     TEMPEARLY_NATIVE_METHOD(iterable_split)
     {
-        Value iterator = args[0].Call(interpreter, "__iter__");
+        Value iterator;
 
-        if (iterator)
+        if (args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
             Handle<ListObject> result = new ListObject(interpreter->cList);
             Handle<ListObject> a = new ListObject(interpreter->cList);
@@ -961,10 +975,11 @@ namespace tempearly
 
             while (iterator.GetNext(interpreter, element))
             {
-                Value result = args[1].Call(interpreter, "__call__", element);
+                Value result;
                 bool slot;
 
-                if (!result || !result.AsBool(interpreter, slot))
+                if (!args[1].CallMethod(interpreter, result, "__call__", element)
+                    || !result.AsBool(interpreter, slot))
                 {
                     return;
                 }
@@ -1008,7 +1023,7 @@ namespace tempearly
             interpreter->Throw(interpreter->eValueError, "Negative count");
             return;
         }
-        else if (!(iterator = args[0].Call(interpreter, "__iter__")))
+        else if (!args[0].CallMethod(interpreter, iterator, "__iter__"))
         {
             return;
         }
@@ -1043,17 +1058,18 @@ namespace tempearly
             bool first = true;
 
             args[0].SetFlag(CountedObject::FLAG_INSPECTING);
-            if (!(iterator = args[0].Call(interpreter, "__iter__")))
+            if (!args[0].CallMethod(interpreter, iterator, "__iter__"))
             {
                 args[0].UnsetFlag(CountedObject::FLAG_INSPECTING);
                 return;
             }
             while (iterator.GetNext(interpreter, element))
             {
-                Value result = element.Call(interpreter, "as_json");
+                Value result;
                 String json;
 
-                if (!result || !result.AsString(interpreter, json))
+                if (!element.CallMethod(interpreter, result, "as_json")
+                    || !result.AsString(interpreter, json))
                 {
                     args[0].UnsetFlag(CountedObject::FLAG_INSPECTING);
                     return;

--- a/src/api/iterator.cc
+++ b/src/api/iterator.cc
@@ -195,7 +195,7 @@ namespace tempearly
         {
             frame->SetReturnValue(Value::NewBool(true));
         }
-        else if (interpreter->GetException().IsInstance(interpreter, interpreter->eStopIteration))
+        else if (interpreter->HasException(interpreter->eStopIteration))
         {
             interpreter->ClearException();
             frame->SetReturnValue(Value::NewBool(false));

--- a/src/api/iterator.h
+++ b/src/api/iterator.h
@@ -23,8 +23,23 @@ namespace tempearly
          * Peeks the next value from iteration without removing it.
          *
          * \param interpreter Script interpreter
+         * \param slot        Where the next value will be assigned into
+         * \return            True if there are more values to be iterated,
+         *                    false otherwise or if there was an exception
+         *                    being thrown
          */
-        Value Peek(const Handle<Interpreter>& interpreter);
+        bool Peek(const Handle<Interpreter>& interpreter);
+
+        /**
+         * Peeks the next value from iteration without removing it.
+         *
+         * \param interpreter Script interpreter
+         * \param slot        Where the next value will be assigned into
+         * \return            True if there are more values to be iterated,
+         *                    false otherwise, or if there was an exception
+         *                    being thrown
+         */
+        bool Peek(const Handle<Interpreter>& interpreter, Value& slot);
 
         /**
          * Returns next value from iteration.

--- a/src/api/list.cc
+++ b/src/api/list.cc
@@ -515,10 +515,10 @@ namespace tempearly
     {
         Handle<ListObject> original = args[0].As<ListObject>();
         Handle<ListObject> result;
-        Value iterator = args[1].Call(interpreter, "__iter__");
+        Value iterator;
         Value element;
 
-        if (!iterator)
+        if (!args[1].CallMethod(interpreter, iterator, "__iter__"))
         {
             return;
         }

--- a/src/api/map.cc
+++ b/src/api/map.cc
@@ -331,8 +331,10 @@ namespace tempearly
         else if (args.GetSize() > 2)
         {
             frame->SetReturnValue(args[2]);
-        } else {
-            frame->SetReturnValue(args[0].Call(interpreter, "__missing__", args[1]));
+        }
+        else if (args[0].CallMethod(interpreter, value, "__missing__", args[1]))
+        {
+            frame->SetReturnValue(value);
         }
     }
 
@@ -542,11 +544,10 @@ namespace tempearly
         {
             Value value;
 
-            if (args[0].As<MapObject>()->Find(hash, value))
+            if (args[0].As<MapObject>()->Find(hash, value)
+                || args[0].CallMethod(interpreter, value, "__missing__", args[1]))
             {
                 frame->SetReturnValue(value);
-            } else {
-                frame->SetReturnValue(args[0].Call(interpreter, "__missing__", args[1]));
             }
         }
     }
@@ -627,7 +628,7 @@ namespace tempearly
                 String value;
 
                 if (!entry->GetKey().ToString(interpreter, key)
-                    || !(result = entry->GetValue().Call(interpreter, "as_json"))
+                    || !entry->GetValue().CallMethod(interpreter, result, "as_json")
                     || !result.AsString(interpreter, value))
                 {
                     map->UnsetFlag(CountedObject::FLAG_INSPECTING);

--- a/src/api/object.cc
+++ b/src/api/object.cc
@@ -27,11 +27,6 @@ namespace tempearly
         }
     }
 
-    bool Object::HasAttribute(const String& id) const
-    {
-        return m_attributes && m_attributes->Find(id);
-    }
-
     bool Object::GetAttribute(const String& id, Value& value) const
     {
         if (m_attributes)

--- a/src/api/object.cc
+++ b/src/api/object.cc
@@ -159,7 +159,8 @@ namespace tempearly
                 Value result;
                 String value;
 
-                if (!(result = entry->GetValue().Call(interpreter, "as_json")) || !result.AsString(interpreter, value))
+                if (!entry->GetValue().CallMethod(interpreter, result, "as_json")
+                    || !result.AsString(interpreter, value))
                 {
                     self.UnsetFlag(CountedObject::FLAG_INSPECTING);
                     return;

--- a/src/api/object.h
+++ b/src/api/object.h
@@ -19,8 +19,6 @@ namespace tempearly
 
         Dictionary<Value> GetAllAttributes() const;
 
-        bool HasAttribute(const String& id) const;
-
         bool GetAttribute(const String& id, Value& value) const;
 
         void SetAttribute(const String& id, const Value& value);

--- a/src/api/range.cc
+++ b/src/api/range.cc
@@ -115,6 +115,7 @@ namespace tempearly
                                    const Value& end,
                                    bool exclusive)
                 : IteratorObject(interpreter->cIterator)
+                , m_done(false)
                 , m_current(begin)
                 , m_end(end)
                 , m_exclusive(exclusive) {}
@@ -124,21 +125,21 @@ namespace tempearly
                 Value cmp;
                 bool b;
 
-                if (!m_current)
+                if (m_done)
                 {
                     return Result(Result::KIND_BREAK);
                 }
-                else if (!(cmp = m_current.Call(interpreter, "__lt__", m_end))
-                            || !cmp.AsBool(interpreter, b))
+                else if (m_current.CallMethod(interpreter, cmp, "__lt__", m_end)
+                        || !cmp.AsBool(interpreter, b))
                 {
                     return Result(Result::KIND_ERROR);
                 }
                 else if (b)
                 {
                     Value current = m_current;
-                    Value next = m_current.Call(interpreter, "__inc__");
+                    Value next;
 
-                    if (!next)
+                    if (!m_current.CallMethod(interpreter, next, "__inc__"))
                     {
                         return Result(Result::KIND_ERROR);
                     }
@@ -146,7 +147,7 @@ namespace tempearly
 
                     return Result(Result::KIND_SUCCESS, current);
                 }
-                m_current.Clear();
+                m_done = true;
                 if (m_exclusive)
                 {
                     return Result(Result::KIND_BREAK);
@@ -163,6 +164,7 @@ namespace tempearly
             }
 
         private:
+            bool m_done;
             Value m_current;
             const Value m_end;
             const bool m_exclusive;

--- a/src/api/set.cc
+++ b/src/api/set.cc
@@ -462,11 +462,11 @@ namespace tempearly
     {
         Handle<SetObject> original = args[0].As<SetObject>();
         Handle<SetObject> result;
-        Value iterator = args[1].Call(interpreter, "__iter__");
+        Value iterator;
         Value element;
         i64 hash;
 
-        if (!iterator)
+        if (!args[1].CallMethod(interpreter, iterator, "__iter__"))
         {
             return;
         }
@@ -500,11 +500,11 @@ namespace tempearly
     {
         Handle<SetObject> original = args[0].As<SetObject>();
         Handle<SetObject> result;
-        Value iterator = args[1].Call(interpreter, "__iter__");
+        Value iterator;
         Value element;
         i64 hash;
 
-        if (!iterator)
+        if (!args[1].CallMethod(interpreter, iterator, "__iter__"))
         {
             return;
         }
@@ -534,11 +534,11 @@ namespace tempearly
     {
         Handle<SetObject> original = args[0].As<SetObject>();
         Handle<SetObject> result;
-        Value iterator = args[1].Call(interpreter, "__iter__");
+        Value iterator;
         Value element;
         i64 hash;
 
-        if (!iterator)
+        if (!args[1].CallMethod(interpreter, iterator, "__iter__"))
         {
             return;
         }

--- a/src/api/stream.cc
+++ b/src/api/stream.cc
@@ -47,9 +47,9 @@ namespace tempearly
     {
         const Value& receiver = args[0];
         Vector<Value> one(1, Value::NewInt(1));
-        Value result = receiver.Call(interpreter, "read", one);
+        Value result;
 
-        if (!result)
+        if (!receiver.CallMethod(interpreter, result, "read", one))
         {
             return;
         }
@@ -61,7 +61,7 @@ namespace tempearly
             while (!bytes.IsEmpty() && bytes.GetBack() != '\n')
             {
                 buffer.PushBack(bytes.GetBytes(), bytes.GetLength());
-                if (!(result = receiver.Call(interpreter, "read", one)))
+                if (!receiver.CallMethod(interpreter, result, "read", one))
                 {
                     return;
                 }
@@ -85,7 +85,7 @@ namespace tempearly
             while (!runes.IsEmpty() && runes.GetBack() != '\n')
             {
                 buffer.Append(runes);
-                if (!(result = receiver.Call(interpreter, "read", one)))
+                if (!receiver.CallMethod(interpreter, result, "read", one))
                 {
                     return;
                 }
@@ -136,7 +136,7 @@ namespace tempearly
             {
                 return;
             }
-            else if (!args[0].Call(interpreter, "write", Vector<Value>(1, Value::NewString(string))))
+            else if (!args[0].CallMethod(interpreter, "write", Vector<Value>(1, Value::NewString(string))))
             {
                 return;
             }
@@ -154,11 +154,11 @@ namespace tempearly
 
             Result Generate(const Handle<Interpreter>& interpreter)
             {
-                if (m_stream)
+                if (!m_stream.IsNull())
                 {
-                    Value line = m_stream.Call(interpreter, "readline");
+                    Value line;
 
-                    if (!line)
+                    if (!m_stream.CallMethod(interpreter, line, "readline"))
                     {
                         return Result(Result::KIND_ERROR);
                     }

--- a/src/coreobject.h
+++ b/src/coreobject.h
@@ -26,8 +26,6 @@ namespace tempearly
          */
         virtual Dictionary<Value> GetAllAttributes() const = 0;
 
-        virtual bool HasAttribute(const String& id) const = 0;
-
         virtual bool GetAttribute(const String& id, Value& value) const = 0;
 
         virtual void SetAttribute(const String& id, const Value& value) = 0;
@@ -77,7 +75,7 @@ namespace tempearly
             return false;
         }
 
-        virtual bool IsStaticMethod() const
+        virtual bool IsUnboundMethod() const
         {
             return false;
         }

--- a/src/frame.cc
+++ b/src/frame.cc
@@ -5,10 +5,12 @@ namespace tempearly
 {
     Frame::Frame(const Handle<Frame>& previous,
                  const Handle<Frame>& enclosing_frame,
-                 const Handle<FunctionObject>& function)
+                 const Handle<FunctionObject>& function,
+                 const Vector<Value>& arguments)
         : m_previous(previous.Get())
         , m_enclosing_frame(enclosing_frame.Get())
         , m_function(function.Get())
+        , m_arguments(arguments)
         , m_local_variables(nullptr) {}
 
     Frame::~Frame()
@@ -98,6 +100,14 @@ namespace tempearly
         if (m_enclosing_frame && !m_enclosing_frame->IsMarked())
         {
             m_enclosing_frame->Mark();
+        }
+        if (m_function && !m_function->IsMarked())
+        {
+            m_function->Mark();
+        }
+        for (std::size_t i = 0; i < m_arguments.GetSize(); ++i)
+        {
+            m_arguments[i].Mark();
         }
         if (m_local_variables)
         {

--- a/src/frame.h
+++ b/src/frame.h
@@ -21,10 +21,12 @@ namespace tempearly
          * \param enclosing_frame Handle to enclosing frame
          * \param function        Handle to function being executed by this
          *                        frame
+         * \param arguments       Arguments given for the function invocation
          */
         explicit Frame(const Handle<Frame>& previous,
                        const Handle<Frame>& enclosing_frame,
-                       const Handle<FunctionObject>& function);
+                       const Handle<FunctionObject>& function,
+                       const Vector<Value>& arguments);
 
         ~Frame();
 
@@ -52,6 +54,14 @@ namespace tempearly
         inline Handle<FunctionObject> GetFunction() const
         {
             return m_function;
+        }
+
+        /**
+         * Returns list of arguments given for the function invocation.
+         */
+        inline const Vector<Value>& GetArguments() const
+        {
+            return m_arguments;
         }
 
         /**
@@ -133,6 +143,8 @@ namespace tempearly
         Frame* m_enclosing_frame;
         /** Pointer to function being executed by this frame. */
         FunctionObject* m_function;
+        /** Arguments given for the function invocation. */
+        const Vector<Value> m_arguments;
         /** Container for local variables. */
         Dictionary<Value>* m_local_variables;
         /** Value returned by the function. */

--- a/src/frame.h
+++ b/src/frame.h
@@ -108,15 +108,7 @@ namespace tempearly
         bool ReplaceLocalVariable(const String& id, const Value& value);
 
         /**
-         * Returns true if this frame has a return value.
-         */
-        inline bool HasReturnValue() const
-        {
-            return m_return_value;
-        }
-
-        /**
-         * Returns value returned by the function invocation or error value if
+         * Returns value returned by the function invocation or null value if
          * no value was returned.
          */
         inline const Value& GetReturnValue() const

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -227,12 +227,8 @@ namespace tempearly
                 if (interpreter->HasException())
                 {
                     return false;
-                }
-                else if (frame->HasReturnValue())
-                {
-                    slot = frame->GetReturnValue();
                 } else {
-                    slot = Value::NullValue();
+                    slot = frame->GetReturnValue();
                 }
                 
                 return true;

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -190,7 +190,7 @@ namespace tempearly
 
             bool Invoke(const Handle<Interpreter>& interpreter, const Vector<Value>& args, Value& slot)
             {
-                Handle<Frame> frame = interpreter->PushFrame(Handle<Frame>(), this);
+                Handle<Frame> frame = interpreter->PushFrame(Handle<Frame>(), this, args);
 
                 // Test that we have correct amount of arguments.
                 if (m_arity < 0)
@@ -254,9 +254,11 @@ namespace tempearly
         }
     }
 
-    Handle<Frame> Interpreter::PushFrame(const Handle<Frame>& enclosing, const Handle<FunctionObject>& function)
+    Handle<Frame> Interpreter::PushFrame(const Handle<Frame>& enclosing,
+                                         const Handle<FunctionObject>& function,
+                                         const Vector<Value>& arguments)
     {
-        Handle<Frame> frame = new Frame(m_frame, enclosing, function);
+        Handle<Frame> frame = new Frame(m_frame, enclosing, function, arguments);
 
         m_frame = frame.Get();
 

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -188,9 +188,10 @@ namespace tempearly
                 , m_arity(arity)
                 , m_callback(callback) {}
 
-            bool Invoke(const Handle<Interpreter>& interpreter, const Vector<Value>& args, Value& slot)
+            bool Invoke(const Handle<Interpreter>& interpreter,
+                        const Handle<Frame>& frame)
             {
-                Handle<Frame> frame = interpreter->PushFrame(Handle<Frame>(), this, args);
+                const Vector<Value>& args = frame->GetArguments();
 
                 // Test that we have correct amount of arguments.
                 if (m_arity < 0)
@@ -204,7 +205,6 @@ namespace tempearly
                            << " arguments, got "
                            << String::FromU64(args.GetSize());
                         interpreter->Throw(interpreter->eTypeError, sb.ToString());
-                        interpreter->PopFrame();
 
                         return false;
                     }
@@ -218,20 +218,12 @@ namespace tempearly
                        << " arguments, got "
                        << String::FromU64(args.GetSize());
                     interpreter->Throw(interpreter->eTypeError, sb.ToString());
-                    interpreter->PopFrame();
 
                     return false;
                 }
                 m_callback(interpreter, frame, args);
-                interpreter->PopFrame();
-                if (interpreter->HasException())
-                {
-                    return false;
-                } else {
-                    slot = frame->GetReturnValue();
-                }
-                
-                return true;
+
+                return !interpreter->HasException();
             }
 
         private:
@@ -302,6 +294,11 @@ namespace tempearly
             m_global_variables = new Dictionary<Value>();
         }
         m_global_variables->Insert(id, value);
+    }
+
+    bool Interpreter::HasException(const Handle<Class>& cls)
+    {
+        return m_exception.IsInstance(this, cls);
     }
 
     void Interpreter::Throw(const Handle<Class>& cls, const String& message)

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -86,7 +86,7 @@ namespace tempearly
          */
         inline bool HasException() const
         {
-            return !!m_exception;
+            return !m_exception.IsNull();
         }
 
         /**

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -43,10 +43,12 @@ namespace tempearly
          *
          * \param enclosing Optional handle of enclosing frame
          * \param function  Optional handle of function being executed
+         * \param arguments Optional arguments given for the function
          * \return          Newly created stack frame
          */
         Handle<Frame> PushFrame(const Handle<Frame>& enclosing = Handle<Frame>(),
-                                const Handle<FunctionObject>& function = Handle<FunctionObject>());
+                                const Handle<FunctionObject>& function = Handle<FunctionObject>(),
+                                const Vector<Value>& arguments = Vector<Value>());
 
         /**
          * Pops the most recent stack frame from frame chain.

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -92,6 +92,12 @@ namespace tempearly
         }
 
         /**
+         * Returns true if this interpreter has an uncaught exception of given
+         * type.
+         */
+        bool HasException(const Handle<Class>& cls);
+
+        /**
          * Returns currently uncaught exception or NULL handle if there isn't
          * any.
          */

--- a/src/json/parser.cc
+++ b/src/json/parser.cc
@@ -60,7 +60,7 @@ namespace tempearly
             case 'n':
                 if (parser->ReadRune('u') && parser->ReadRune('l') && parser->ReadRune('l'))
                 {
-                    slot = Value::NullValue();
+                    slot.Clear();
 
                     return true;
                 } else {

--- a/src/script/node.h
+++ b/src/script/node.h
@@ -32,10 +32,12 @@ namespace tempearly
          * Evaluates node as expression.
          *
          * \param interpreter Script interpreter
-         * \return            Value returned by the expression, or error value
-         *                    if an exception was thrown
+         * \param slot        Where value returned by the expression will be
+         *                    stored
+         * \return            True if evaluation was successfull, false if an
+         *                    exception was thrown
          */
-        Value Evaluate(const Handle<Interpreter>& interpreter) const;
+        bool Evaluate(const Handle<Interpreter>& interpreter, Value& slot) const;
 
         /**
          * Uses node as variable and assigns an value into it.

--- a/src/script/parameter.cc
+++ b/src/script/parameter.cc
@@ -77,9 +77,9 @@ namespace tempearly
             }
             else if (parameter->m_default_value)
             {
-                Value value = parameter->m_default_value->Evaluate(interpreter);
+                Value value;
 
-                if (!value)
+                if (!parameter->m_default_value->Evaluate(interpreter, value))
                 {
                     return false;
                 }

--- a/src/script/parser.cc
+++ b/src/script/parser.cc
@@ -1568,7 +1568,7 @@ SCAN_EXPONENT:
                 break;
 
             case Token::KW_NULL:
-                node = new ValueNode(Value::NullValue());
+                node = new ValueNode(Value());
                 break;
 
             case Token::STRING:

--- a/src/script/result.h
+++ b/src/script/result.h
@@ -80,15 +80,7 @@ namespace tempearly
         }
 
         /**
-         * Returns true if the result contains an value.
-         */
-        inline bool HasValue() const
-        {
-            return !!m_value;
-        }
-
-        /**
-         * Returns an optional value returned by the result, or error value if
+         * Returns an optional value returned by the result, or null value if
          * no value was returned.
          */
         inline const Value& GetValue() const

--- a/src/script/typehint.cc
+++ b/src/script/typehint.cc
@@ -17,9 +17,9 @@ namespace tempearly
 
             bool Accepts(const Handle<Interpreter>& interpreter, const Value& value, bool& slot) const
             {
-                Value cls = m_node->Evaluate(interpreter);
+                Value cls;
 
-                if (!cls)
+                if (!m_node->Evaluate(interpreter, cls))
                 {
                     return false;
                 }

--- a/src/value.h
+++ b/src/value.h
@@ -187,14 +187,14 @@ namespace tempearly
             return m_kind == KIND_OBJECT && m_data.o->IsSet();
         }
 
-        inline bool IsStaticMethod() const
-        {
-            return m_kind == KIND_OBJECT && m_data.o->IsStaticMethod();
-        }
-
         inline bool IsString() const
         {
             return m_kind == KIND_STRING;
+        }
+
+        inline bool IsUnboundMethod() const
+        {
+            return m_kind == KIND_OBJECT && m_data.o->IsUnboundMethod();
         }
 
         Handle<Class> GetClass(const Handle<Interpreter>& interpreter) const;
@@ -204,13 +204,11 @@ namespace tempearly
          */
         Dictionary<Value> GetAllAttributes() const;
 
-        bool HasAttribute(const String& id) const;
-
         bool GetAttribute(const Handle<Interpreter>& interpreter,
-                          const String& id,
-                          Value& value) const;
+                          const String& name,
+                          Value& slot) const;
 
-        bool SetAttribute(const String& id, const Value& value) const;
+        bool SetAttribute(const String& name, const Value& value) const;
 
         bool CallMethod(const Handle<Interpreter>& interpreter,
                         Value& slot,

--- a/src/value.h
+++ b/src/value.h
@@ -17,18 +17,17 @@ namespace tempearly
     public:
         enum Kind
         {
-            KIND_ERROR  = 0,
-            KIND_NULL   = 1,
-            KIND_BOOL   = 2,
-            KIND_INT    = 3,
-            KIND_FLOAT  = 4,
-            KIND_STRING = 5,
-            KIND_BINARY = 6,
-            KIND_OBJECT = 7
+            KIND_NULL   = 0,
+            KIND_BOOL   = 1,
+            KIND_INT    = 2,
+            KIND_FLOAT  = 3,
+            KIND_STRING = 4,
+            KIND_BINARY = 5,
+            KIND_OBJECT = 6
         };
 
         /**
-         * Constructs error value.
+         * Constructs null value.
          */
         Value();
 
@@ -56,11 +55,6 @@ namespace tempearly
          * Destructor.
          */
         virtual ~Value();
-
-        /**
-         * Returns null value.
-         */
-        static const Value& NullValue();
 
         /**
          * Constructs boolean value.
@@ -218,13 +212,23 @@ namespace tempearly
 
         bool SetAttribute(const String& id, const Value& value) const;
 
-        Value Call(const Handle<Interpreter>& interpreter,
-                   const String& id,
-                   const Vector<Value>& args = Vector<Value>()) const;
+        bool CallMethod(const Handle<Interpreter>& interpreter,
+                        Value& slot,
+                        const String& method_name,
+                        const Vector<Value>& args = Vector<Value>()) const;
 
-        Value Call(const Handle<Interpreter>& interpreter,
-                   const String& id,
-                   const Value& arg) const;
+        bool CallMethod(const Handle<Interpreter>& interpreter,
+                        Value& slot,
+                        const String& method_name,
+                        const Value& arg) const;
+
+        bool CallMethod(const Handle<Interpreter>& interpreter,
+                        const String& method_name,
+                        const Vector<Value>& args = Vector<Value>()) const;
+
+        bool CallMethod(const Handle<Interpreter>& interpreter,
+                        const String& method_name,
+                        const Value& arg) const;
 
         /**
          * Performs equality test between two values. This is done by invoking
@@ -351,16 +355,6 @@ namespace tempearly
             {
                 m_data.o->UnsetFlag(flag);
             }
-        }
-
-        inline operator bool() const
-        {
-            return m_kind != KIND_ERROR;
-        }
-
-        inline bool operator!() const
-        {
-            return m_kind == KIND_ERROR;
         }
 
     private:


### PR DESCRIPTION
I believe that it is unnecessary to have separate error value, when you could just design methods used by `Value` class so that they return an boolean indicating whether an error occurred or not.

Second commit stores function arguments in `Frame` class so that they can be reached by garbage collector through the stack frame.

Also fixes a bug where the function itself which already is stored in the `Frame` is not being marked by the garbage collection process. Oops.

After these changes I can run the quicksort example in built-in HTTPD a few times without it crashing. Seems like progress to me.