### PR TITLE
Add REPL support to Tempearly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,12 @@ OPTION(
 )
 
 OPTION(
+    ENABLE_REPL_SAPI
+    "Enable REPL"
+    OFF
+)
+
+OPTION(
     TEMPEARLY_GC_DEBUG
     "Display debugging messages from GC"
     OFF
@@ -198,6 +204,16 @@ IF (ENABLE_HTTPD_SAPI)
         src/sapi/httpd/request.cc
         src/sapi/httpd/response.cc
         src/sapi/httpd/server.cc
+        ${INTERPRETER_SOURCES}
+    )
+ENDIF()
+
+IF (ENABLE_REPL_SAPI)
+    ADD_EXECUTABLE(
+        tempearly-repl
+        src/sapi/repl/main.cc
+        src/sapi/repl/request.cc
+        src/sapi/repl/response.cc
         ${INTERPRETER_SOURCES}
     )
 ENDIF()

--- a/src/api/function.cc
+++ b/src/api/function.cc
@@ -207,6 +207,18 @@ namespace tempearly
         return new UnboundMethod(interpreter, cls, arity, callback);
     }
 
+    String FunctionObject::GetName() const
+    {
+        Handle<Object> value;
+
+        if (GetOwnAttribute("__name__", value) && value->IsString())
+        {
+            return value->AsString();
+        } else {
+            return "<anonymous function>";
+        }
+    }
+
     bool FunctionObject::Invoke(const Handle<Interpreter>& interpreter,
                                 Handle<Object>& slot,
                                 const Vector<Handle<Object>>& args)

--- a/src/api/function.h
+++ b/src/api/function.h
@@ -60,6 +60,12 @@ namespace tempearly
         );
 
         /**
+         * Returns name of the function or "<anonymous function>" if this
+         * function has no name.
+         */
+        String GetName() const;
+
+        /**
          * Invokes the function.
          *
          * \param interpreter Script interpreter

--- a/src/sapi/repl/main.cc
+++ b/src/sapi/repl/main.cc
@@ -1,0 +1,240 @@
+#include "interpreter.h"
+#include "core/bytestring.h"
+#include "io/stream.h"
+#include "sapi/repl/request.h"
+#include "sapi/repl/response.h"
+#include "script/parser.h"
+
+using namespace tempearly;
+
+static ByteString repl_read_expr(int&);
+static void repl_read_line(int&, Vector<byte>&);
+static void repl_show_exception(const Handle<Interpreter>&);
+static void count_open_chars(const Vector<byte>&, Vector<byte>&);
+
+int main(int argc, char** argv)
+{
+    Handle<Interpreter> interpreter;
+    int line_counter = 0;
+
+    interpreter = new Interpreter(new ReplRequest(), new ReplResponse());
+    interpreter->Initialize();
+    interpreter->PushFrame();
+    for (;;)
+    {
+        const ByteString line = repl_read_expr(line_counter);
+        Handle<ScriptParser> parser;
+        Handle<Script> script;
+
+        // Skip empty lines.
+        if (line.IsEmpty())
+        {
+            continue;
+        }
+        parser = new ScriptParser(line.AsStream());
+        if ((script = parser->CompileExpression()))
+        {
+            Handle<Object> result;
+
+            if (script->Evaluate(interpreter, result))
+            {
+                // Skip null values.
+                if (!result->IsNull())
+                {
+                    String repr;
+
+                    if (result->ToString(interpreter, repr))
+                    {
+                        std::printf("=> %s\n", repr.Encode().c_str());
+                    } else {
+                        repl_show_exception(interpreter);
+                    }
+                }
+            } else {
+                repl_show_exception(interpreter);
+            }
+        } else {
+            std::printf(
+                "SyntaxError: %s\n",
+                parser->GetErrorMessage().Encode().c_str()
+            );
+        }
+    }
+
+    return EXIT_SUCCESS;
+}
+
+static ByteString repl_read_expr(int& line_counter)
+{
+    Vector<byte> buffer;
+    Vector<byte> line;
+    Vector<byte> open_chars;
+
+    for (;;)
+    {
+        repl_read_line(line_counter, line);
+        count_open_chars(line, open_chars);
+        if (!buffer.IsEmpty())
+        {
+            buffer.PushBack(static_cast<byte>('\n'));
+        }
+        buffer.PushBack(line.GetData(), line.GetSize());
+        line.Clear();
+        if (open_chars.IsEmpty())
+        {
+            return ByteString(buffer.GetData(), buffer.GetSize());
+        }
+    }
+}
+
+static void repl_read_line(int& line_counter, Vector<byte>& buffer)
+{
+    std::printf("tempearly:%03d> ", ++line_counter);
+    for (;;)
+    {
+        const int c = std::fgetc(stdin);
+
+        if (c == EOF)
+        {
+            std::exit(EXIT_SUCCESS);
+        }
+        else if (c == '\n')
+        {
+            return;
+        } else {
+            buffer.PushBack(c);
+        }
+    }
+}
+
+static void repl_show_exception(const Handle<Interpreter>& interpreter)
+{
+    const Handle<ExceptionObject> exception(interpreter->GetException());
+
+    if (!exception)
+    {
+        return;
+    }
+    interpreter->ClearException();
+    std::printf(
+        "%s: %s\n",
+        exception->GetClass(interpreter)->GetName().Encode().c_str(),
+        exception->GetMessage().Encode().c_str()
+    );
+    for (Handle<Frame> frame = exception->GetFrame();
+         frame;
+         frame = frame->GetPrevious())
+    {
+        const Handle<FunctionObject> function = frame->GetFunction();
+
+        std::printf(
+            "\t%s\n",
+            function ? function->GetName().Encode().c_str() : "<eval>"
+        );
+    }
+}
+
+static void count_open_chars(const Vector<byte>& input,
+                             Vector<byte>& open_chars)
+{
+    const std::size_t size = input.GetSize();
+
+    for (std::size_t i = 0; i < size; ++i)
+    {
+        if (!open_chars.IsEmpty())
+        {
+            const byte b = open_chars.GetBack();
+
+            if (b == '"' || b == '\'')
+            {
+                while (i < size)
+                {
+                    if (input[i] == b)
+                    {
+                        open_chars.Erase(open_chars.GetSize() - 1);
+                        ++i;
+                        break;
+                    }
+                    else if (input[i] == '\\' && i + 1 < size)
+                    {
+                        if (input[++i] == b)
+                        {
+                            ++i;
+                        }
+                    } else {
+                        ++i;
+                    }
+                }
+                if (i >= size)
+                {
+                    break;
+                }
+            }
+            else if (b == '*')
+            {
+                while (i < size)
+                {
+                    if (input[i] == '*'
+                        && i + 1 < size
+                        && input[i + 1] == '/')
+                    {
+                        open_chars.Erase(open_chars.GetSize() - 1);
+                        ++i;
+                        break;
+                    } else {
+                        ++i;
+                    }
+                }
+            }
+        }
+        switch (input[i])
+        {
+            case '#':
+                return;
+
+            case '/':
+                if (i + 1 < size && input[i + 1] == '*')
+                {
+                    open_chars.PushBack('*');
+                    ++i;
+                }
+                break;
+
+            case '(': open_chars.PushBack(')'); break;
+            case '[': open_chars.PushBack(']'); break;
+            case '{': open_chars.PushBack('}'); break;
+
+            case ')': case ']': case '}':
+                if (!open_chars.IsEmpty() && open_chars.GetBack() == input[i])
+                {
+                    open_chars.Erase(open_chars.GetSize() - 1);
+                }
+                break;
+
+            case '\'': case '"':
+            {
+                const byte separator = input[i];
+
+                open_chars.PushBack(separator);
+                ++i;
+                while (i < size)
+                {
+                    if (input[i] == separator)
+                    {
+                        open_chars.Erase(open_chars.GetSize() - 1);
+                        break;
+                    }
+                    else if (input[i] == '\\')
+                    {
+                        if (++i < size && input[i] == '\'')
+                        {
+                            ++i;
+                        }
+                    } else {
+                        ++i;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/sapi/repl/request.cc
+++ b/src/sapi/repl/request.cc
@@ -1,0 +1,47 @@
+#include "core/bytestring.h"
+#include "sapi/repl/request.h"
+
+namespace tempearly
+{
+    ReplRequest::ReplRequest() {}
+
+    HttpMethod::Kind ReplRequest::GetMethod() const
+    {
+        return HttpMethod::GET;
+    }
+
+    String ReplRequest::GetPath() const
+    {
+        return "/";
+    }
+
+    bool ReplRequest::IsSecure() const
+    {
+        return false;
+    }
+
+    bool ReplRequest::IsAjax() const
+    {
+        return false;
+    }
+
+    String ReplRequest::GetContentType() const
+    {
+        return String();
+    }
+
+    std::size_t ReplRequest::GetContentLength() const
+    {
+        return 0;
+    }
+
+    ByteString ReplRequest::GetBody()
+    {
+        return ByteString();
+    }
+
+    ByteString ReplRequest::GetQueryString()
+    {
+        return ByteString();
+    }
+}

--- a/src/sapi/repl/request.h
+++ b/src/sapi/repl/request.h
@@ -1,0 +1,38 @@
+#ifndef TEMPEARLY_SAPI_REPL_REQUEST_H_GUARD
+#define TEMPEARLY_SAPI_REPL_REQUEST_H_GUARD
+
+#include "sapi/request.h"
+
+namespace tempearly
+{
+    class ReplRequest : public Request
+    {
+    public:
+        explicit ReplRequest();
+
+        HttpMethod::Kind GetMethod() const;
+
+        String GetPath() const;
+
+        bool IsSecure() const;
+
+        bool IsAjax() const;
+
+        String GetContentType() const;
+
+        std::size_t GetContentLength() const;
+
+        ByteString GetBody();
+
+        ByteString GetQueryString();
+
+        bool HasHeader(const String& id) const;
+
+        bool GetHeader(const String& id, String& slot) const;
+
+    private:
+        TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(ReplRequest);
+    };
+}
+
+#endif /* !TEMPEARLY_SAPI_REPL_REQUEST_H_GUARD */

--- a/src/sapi/repl/response.cc
+++ b/src/sapi/repl/response.cc
@@ -1,0 +1,24 @@
+#include "core/bytestring.h"
+#include "sapi/repl/response.h"
+
+namespace tempearly
+{
+    ReplResponse::ReplResponse() {}
+
+    bool ReplResponse::IsCommitted() const
+    {
+        return false;
+    }
+
+    void ReplResponse::Commit() {}
+
+    void ReplResponse::Write(const ByteString& data)
+    {
+        std::fwrite(
+            static_cast<const void*>(data.GetBytes()),
+            sizeof(byte),
+            data.GetLength(),
+            stdout
+        );
+    }
+}

--- a/src/sapi/repl/response.h
+++ b/src/sapi/repl/response.h
@@ -1,0 +1,24 @@
+#ifndef TEMPEARLY_SAPI_REPL_RESPONSE_H_GUARD
+#define TEMPEARLY_SAPI_REPL_RESPONSE_H_GUARD
+
+#include "sapi/response.h"
+
+namespace tempearly
+{
+    class ReplResponse : public Response
+    {
+    public:
+        explicit ReplResponse();
+
+        bool IsCommitted() const;
+
+        void Commit();
+
+        void Write(const ByteString& data);
+
+    private:
+        TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(ReplResponse);
+    };
+}
+
+#endif /* !TEMPEARLY_SAPI_REPL_RESPONSE_H_GUARD */

--- a/src/script/parser.cc
+++ b/src/script/parser.cc
@@ -84,6 +84,18 @@ namespace tempearly
         return new Script(nodes);
     }
 
+    Handle<Script> ScriptParser::CompileExpression()
+    {
+        const Handle<Node> expr = parse_expr(this);
+
+        if (expr)
+        {
+            return new Script(Vector<Handle<Node>>(1, expr));
+        } else {
+            return Handle<Script>();
+        }
+    }
+
     const ScriptParser::TokenDescriptor& ScriptParser::PeekToken()
     {
         if (m_pushback_tokens.IsEmpty())

--- a/src/script/parser.h
+++ b/src/script/parser.h
@@ -24,6 +24,8 @@ namespace tempearly
 
         Handle<Script> Compile();
 
+        Handle<Script> CompileExpression();
+
         const TokenDescriptor& PeekToken();
 
         bool PeekToken(Token::Kind kind);

--- a/src/script/script.cc
+++ b/src/script/script.cc
@@ -41,6 +41,26 @@ namespace tempearly
         return true;
     }
 
+    bool Script::Evaluate(const Handle<Interpreter>& interpreter,
+                          Handle<Object>& result) const
+    {
+        if (m_nodes.IsEmpty())
+        {
+            result = Object::NewNull();
+
+            return true;
+        }
+        for (std::size_t i = 0; i < m_nodes.GetSize(); ++i)
+        {
+            if (!m_nodes[i]->Evaluate(interpreter, result))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     void Script::Mark()
     {
         CountedObject::Mark();

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -15,6 +15,11 @@ namespace tempearly
 
         bool Execute(const Handle<Interpreter>& interpreter) const;
 
+        bool Evaluate(
+            const Handle<Interpreter>& interpreter,
+            Handle<Object>& slot
+        ) const;
+
         void Mark();
 
     private:


### PR DESCRIPTION
This is something I found useful while developing Tempearly: A pseudo SAPI which adds REPL support to Tempearly. It's an command line user interface where you type in Tempearly expressions, which are then parsed and evaluated and finally result of the expression is displayed to user. Exceptions are also printed with full stack trace for examination.