### PR TITLE
Two bugfixes.

### DIFF
--- a/src/api/file.h
+++ b/src/api/file.h
@@ -16,6 +16,11 @@ namespace tempearly
             return m_path;
         }
 
+        bool IsFile() const
+        {
+            return true;
+        }
+
     private:
         const Filename m_path;
         TEMPEARLY_DISALLOW_COPY_AND_ASSIGN(FileObject);

--- a/src/object.cc
+++ b/src/object.cc
@@ -28,7 +28,22 @@ namespace tempearly
 
         const Handle<Class> cls = GetClass(interpreter);
 
-        if (cls->GetAttribute(interpreter, name, slot))
+        if (cls == interpreter->cClass)
+        {
+            if (cls->GetOwnAttribute(name, slot))
+            {
+                if (slot->IsUnboundMethod())
+                {
+                    slot = slot.As<FunctionObject>()->Curry(
+                        interpreter,
+                        Vector<Handle<Object>>(1, this)
+                    );
+                }
+
+                return true;
+            }
+        }
+        else if (cls->GetAttribute(interpreter, name, slot))
         {
             if (slot->IsUnboundMethod())
             {


### PR DESCRIPTION
1. Fix non-existent attribute lookup which currently results in endless
   loop by adding a special case for class `Class` in the attribute
   lookup.
2. Make file objects to be recognized as file objects.