### PR TITLE
Do not allow unary expression after prefix expression.

### DIFF
--- a/src/script/parser.cc
+++ b/src/script/parser.cc
@@ -1786,8 +1786,8 @@ SCAN_EXPONENT:
      * "-" unary-expression
      * "!" unary-expression
      * "~" unary-expression
-     * "++" unary-expression
-     * "--" unary-expression
+     * "++" postfix-expression
+     * "--" postfix-expression
      */
     static Handle<Node> parse_unary(const Handle<ScriptParser>& parser)
     {
@@ -1836,7 +1836,7 @@ SCAN_EXPONENT:
                     PrefixNode::INCREMENT : PrefixNode::DECREMENT;
 
                 parser->SkipToken();
-                if (!(node = parse_unary(parser)))
+                if (!(node = parse_postfix(parser)))
                 {
                     return Handle<Node>();
                 }


### PR DESCRIPTION
None of the unary expressions can be assignable, so there is no point to parse unary expression as operand when `++` or `--` prefix expression is encountered.